### PR TITLE
GPII-1112: screen readers: _disabled=true

### DIFF
--- a/manualDataThirdPhase/vladimirov_000.ini
+++ b/manualDataThirdPhase/vladimirov_000.ini
@@ -60,6 +60,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 7.875
   cloud4allVoiceProfile-GlobalContext.Punctuation = 3
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_001.ini
+++ b/manualDataThirdPhase/vladimirov_001.ini
@@ -60,6 +60,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 9.500
   cloud4allVoiceProfile-GlobalContext.Punctuation = 3
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_002.ini
+++ b/manualDataThirdPhase/vladimirov_002.ini
@@ -54,6 +54,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 35.16
   speech.symbolLevel = 300
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_003.ini
+++ b/manualDataThirdPhase/vladimirov_003.ini
@@ -60,6 +60,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 12.875
   cloud4allVoiceProfile-GlobalContext.Punctuation = 3
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_004.ini
+++ b/manualDataThirdPhase/vladimirov_004.ini
@@ -54,6 +54,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 41.94
   speech.symbolLevel = 300
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_005.ini
+++ b/manualDataThirdPhase/vladimirov_005.ini
@@ -60,6 +60,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 15.375
   cloud4allVoiceProfile-GlobalContext.Punctuation = 3
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_006.ini
+++ b/manualDataThirdPhase/vladimirov_006.ini
@@ -54,6 +54,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 46.77
   speech.symbolLevel = 300
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_007.ini
+++ b/manualDataThirdPhase/vladimirov_007.ini
@@ -60,6 +60,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 16.750
   cloud4allVoiceProfile-GlobalContext.Punctuation = 3
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_008.ini
+++ b/manualDataThirdPhase/vladimirov_008.ini
@@ -54,6 +54,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 51.61
   speech.symbolLevel = 300
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_100.ini
+++ b/manualDataThirdPhase/vladimirov_100.ini
@@ -61,6 +61,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 7.875
   cloud4allVoiceProfile-GlobalContext.Punctuation = 3
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_101.ini
+++ b/manualDataThirdPhase/vladimirov_101.ini
@@ -54,6 +54,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 30
   speech.symbolLevel = 300
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_102.ini
+++ b/manualDataThirdPhase/vladimirov_102.ini
@@ -60,6 +60,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 11.500
   cloud4allVoiceProfile-GlobalContext.Punctuation = 3
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_103.ini
+++ b/manualDataThirdPhase/vladimirov_103.ini
@@ -54,6 +54,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 38.71
   speech.symbolLevel = 300
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_104.ini
+++ b/manualDataThirdPhase/vladimirov_104.ini
@@ -60,6 +60,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 14.125
   cloud4allVoiceProfile-GlobalContext.Punctuation = 3
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_105.ini
+++ b/manualDataThirdPhase/vladimirov_105.ini
@@ -54,6 +54,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 45.16
   speech.symbolLevel = 300
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_106.ini
+++ b/manualDataThirdPhase/vladimirov_106.ini
@@ -60,6 +60,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 16.000
   cloud4allVoiceProfile-GlobalContext.Punctuation = 3
+  _disabled=true
 
 
 [preferences]


### PR DESCRIPTION
Added  _disabled=true to prevent the launch of two screen readers on the
same platform (NVDA, JAWS, SuperNova).
