### PR TITLE
GPII-1112: screen readers: _disabled=true (2)

### DIFF
--- a/manualDataThirdPhase/vladimirov_large_000.ini
+++ b/manualDataThirdPhase/vladimirov_large_000.ini
@@ -63,6 +63,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 7.875
   cloud4allVoiceProfile-GlobalContext.Punctuation = 3
+  _disabled=true
 
 
 [preferences]
@@ -76,3 +77,4 @@ app = "http://registry.gpii.net/applications/org.gnome.orca"
 app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
   cursor-size = 29
   text-scaling-factor = 1.8
+

--- a/manualDataThirdPhase/vladimirov_large_001.ini
+++ b/manualDataThirdPhase/vladimirov_large_001.ini
@@ -57,6 +57,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 30
   speech.symbolLevel = 300
+  _disabled=true
 
 
 [preferences]
@@ -76,3 +77,4 @@ app = "http://registry.gpii.net/applications/org.gnome.orca"
 app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
   cursor-size = 29
   text-scaling-factor = 1.8
+

--- a/manualDataThirdPhase/vladimirov_large_002.ini
+++ b/manualDataThirdPhase/vladimirov_large_002.ini
@@ -63,6 +63,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 11.500
   cloud4allVoiceProfile-GlobalContext.Punctuation = 3
+  _disabled=true
 
 
 [preferences]
@@ -76,3 +77,4 @@ app = "http://registry.gpii.net/applications/org.gnome.orca"
 app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
   cursor-size = 29
   text-scaling-factor = 1.8
+

--- a/manualDataThirdPhase/vladimirov_large_003.ini
+++ b/manualDataThirdPhase/vladimirov_large_003.ini
@@ -57,6 +57,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 38.71
   speech.symbolLevel = 300
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_004.ini
+++ b/manualDataThirdPhase/vladimirov_large_004.ini
@@ -63,6 +63,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 14.125
   cloud4allVoiceProfile-GlobalContext.Punctuation = 3
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_100.ini
+++ b/manualDataThirdPhase/vladimirov_large_100.ini
@@ -63,6 +63,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 25.81
   speech.symbolLevel = 300
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_101.ini
+++ b/manualDataThirdPhase/vladimirov_large_101.ini
@@ -69,6 +69,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 9.500
   cloud4allVoiceProfile-GlobalContext.Punctuation = 1
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_102.ini
+++ b/manualDataThirdPhase/vladimirov_large_102.ini
@@ -63,6 +63,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 35.16
   speech.symbolLevel = 100
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_103.ini
+++ b/manualDataThirdPhase/vladimirov_large_103.ini
@@ -69,6 +69,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 12.875
   cloud4allVoiceProfile-GlobalContext.Punctuation = 1
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_104.ini
+++ b/manualDataThirdPhase/vladimirov_large_104.ini
@@ -63,6 +63,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 41.94
   speech.symbolLevel = 100
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_105.ini
+++ b/manualDataThirdPhase/vladimirov_large_105.ini
@@ -69,6 +69,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 15.375
   cloud4allVoiceProfile-GlobalContext.Punctuation = 1
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_106.ini
+++ b/manualDataThirdPhase/vladimirov_large_106.ini
@@ -63,6 +63,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 46.77
   speech.symbolLevel = 100
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_107.ini
+++ b/manualDataThirdPhase/vladimirov_large_107.ini
@@ -69,6 +69,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 16.625
   cloud4allVoiceProfile-GlobalContext.Punctuation = 1
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_108.ini
+++ b/manualDataThirdPhase/vladimirov_large_108.ini
@@ -63,6 +63,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 51.61
   speech.symbolLevel = 100
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_109.ini
+++ b/manualDataThirdPhase/vladimirov_large_109.ini
@@ -69,6 +69,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 19.125
   cloud4allVoiceProfile-GlobalContext.Punctuation = 1
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_110.ini
+++ b/manualDataThirdPhase/vladimirov_large_110.ini
@@ -63,6 +63,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 58.06
   speech.symbolLevel = 100
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_111.ini
+++ b/manualDataThirdPhase/vladimirov_large_111.ini
@@ -69,6 +69,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 21.625
   cloud4allVoiceProfile-GlobalContext.Punctuation = 1
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_112.ini
+++ b/manualDataThirdPhase/vladimirov_large_112.ini
@@ -63,6 +63,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   speech.outputDevice = "Microsoft Sound Mapper"
   speech.espeak.rate = 64.52
   speech.symbolLevel = 100
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_113.ini
+++ b/manualDataThirdPhase/vladimirov_large_113.ini
@@ -69,6 +69,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 24.125
   cloud4allVoiceProfile-GlobalContext.Punctuation = 1
+  _disabled=true
 
 
 [preferences]

--- a/manualDataThirdPhase/vladimirov_large_114.ini
+++ b/manualDataThirdPhase/vladimirov_large_114.ini
@@ -69,6 +69,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   cloud4allVoiceProfile-GlobalContext.Speed = 25.375
   cloud4allVoiceProfile-GlobalContext.Punctuation = 1
+  _disabled=true
 
 
 [preferences]


### PR DESCRIPTION
Added _disabled=true to prevent the launch of two screen readers on the
same platform (NVDA, JAWS).
