### PR TITLE
GPII-1112: Windows Magnifier and SuperNova

### DIFF
--- a/manualDataThirdPhase/win7_magnifier_1-1.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-1.ini
@@ -1,0 +1,49 @@
+[context]
+user = "win7_magnifier_1-1"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.1
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 110
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  ; SuperNova magnification starts at 1.2, not at 1.1
+  "magnification": 1.2
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.1
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.1
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 26.4 = 12 * 2 * 1.1 
+  "map\\.string\\.fontsize\\.$t": 26.4
+  ; @@iconsize scale to be confirmed by Omnitor
+

--- a/manualDataThirdPhase/win7_magnifier_1-1_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-1_sn.ini
@@ -1,0 +1,41 @@
+[context]
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.1
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 110
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.1
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.1
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 26.4 = 12 * 2 * 1.1 
+  "map\\.string\\.fontsize\\.$t": 26.4
+  ; @@iconsize scale to be confirmed by Omnitor
+
+

--- a/manualDataThirdPhase/win7_magnifier_1-1_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-1_sn.ini
@@ -1,4 +1,5 @@
 [context]
+user = "win7_magnifier_1-1_sn"
 os = "windows"
 
 [preferences]
@@ -14,6 +15,14 @@ app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  ; SuperNova magnification starts at 1.2, not at 1.1
+  "magnification": 1.2
+  "magnifierPosition": "FullScreen"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
@@ -37,5 +46,4 @@ app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; 26.4 = 12 * 2 * 1.1 
   "map\\.string\\.fontsize\\.$t": 26.4
   ; @@iconsize scale to be confirmed by Omnitor
-
 

--- a/manualDataThirdPhase/win7_magnifier_1-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-2.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-2"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.2
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 120
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.2
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.2
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.2
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 28.8 = 12 * 2 * 1.2 
+  "map\\.string\\.fontsize\\.$t": 28.8
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 84 = 70 * 1.2
+  "map\\.string\\.iconsize\\.$t": 84
+

--- a/manualDataThirdPhase/win7_magnifier_1-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-2_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-2_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.2
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 120
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.2
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.2
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.2
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 28.8 = 12 * 2 * 1.2 
+  "map\\.string\\.fontsize\\.$t": 28.8
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 84 = 70 * 1.2
+  "map\\.string\\.iconsize\\.$t": 84
+

--- a/manualDataThirdPhase/win7_magnifier_1-3.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-3.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-3"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.3
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 130
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.3
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.3
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 31.2 = 12 * 2 * 1.3 
+  "map\\.string\\.fontsize\\.$t": 31.2
+  ; @@iconsize ID and scale to be confirmed by Omnitor
+  ; 91 = 70 * 1.3
+  "map\\.string\\.iconsize\\.$t": 91
+

--- a/manualDataThirdPhase/win7_magnifier_1-3_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-3_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-3_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.3
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 130
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.3
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.3
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 31.2 = 12 * 2 * 1.3 
+  "map\\.string\\.fontsize\\.$t": 31.2
+  ; @@iconsize ID and scale to be confirmed by Omnitor
+  ; 91 = 70 * 1.3
+  "map\\.string\\.iconsize\\.$t": 91
+

--- a/manualDataThirdPhase/win7_magnifier_1-4.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-4.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-4"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.4
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 140
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.4
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.4
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.4
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 33.6 = 12 * 2 * 1.4 
+  "map\\.string\\.fontsize\\.$t": 33.6
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 98 = 70 * 1.4
+  "map\\.string\\.iconsize\\.$t": 98
+

--- a/manualDataThirdPhase/win7_magnifier_1-4_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-4_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-4_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.4
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 140
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.4
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.4
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.4
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 33.6 = 12 * 2 * 1.4 
+  "map\\.string\\.fontsize\\.$t": 33.6
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 98 = 70 * 1.4
+  "map\\.string\\.iconsize\\.$t": 98
+

--- a/manualDataThirdPhase/win7_magnifier_1-5.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-5.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-5"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.5
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 150
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.5
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.5
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.5
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 36 = 12 * 2 * 1.5 
+  "map\\.string\\.fontsize\\.$t": 36
+  ; @@iconsize ID and scale to be confirmed by Omnitor
+  ; 105 = 70 * 1.5; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_1-5_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-5_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-5_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.5
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 150
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.5
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.5
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.5
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 36 = 12 * 2 * 1.5 
+  "map\\.string\\.fontsize\\.$t": 36
+  ; @@iconsize ID and scale to be confirmed by Omnitor
+  ; 105 = 70 * 1.5; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_1-6.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-6.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-6"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.6
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 160
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.6
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.6
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.6
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 38.4 = 12 * 2 * 1.6 
+  "map\\.string\\.fontsize\\.$t": 38.4
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 112 = 70 * 1.6; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_1-6_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-6_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-6_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.6
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 160
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.6
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.6
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.6
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 38.4 = 12 * 2 * 1.6 
+  "map\\.string\\.fontsize\\.$t": 38.4
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 112 = 70 * 1.6; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_1-7.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-7.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-7"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.7
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 170
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.7
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.7
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+	"screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.7
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 40.8 = 12 * 2 * 1.7 
+  "map\\.string\\.fontsize\\.$t": 40.8
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 119 = 70 * 1.7; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_1-7_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-7_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-7_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.7
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 170
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.7
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.7
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+	"screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.7
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 40.8 = 12 * 2 * 1.7 
+  "map\\.string\\.fontsize\\.$t": 40.8
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 119 = 70 * 1.7; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_1-8.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-8.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-8"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.8
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 180
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.8
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.8
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+	"screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 43.2 = 12 * 2 * 1.8 
+  "map\\.string\\.fontsize\\.$t": 43.2
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 126 = 70 * 1.8; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_1-8_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-8_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-8_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.8
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 180
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.8
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.8
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+	"screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 43.2 = 12 * 2 * 1.8 
+  "map\\.string\\.fontsize\\.$t": 43.2
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 126 = 70 * 1.8; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_1-9.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-9.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-9"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.9
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 190
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.9
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.9
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.9
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 45.6 = 12 * 2 * 1.9 
+  "map\\.string\\.fontsize\\.$t": 45.6
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 133 = 70 * 1.9; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_1-9_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-9_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_1-9_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.9
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 190
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.9
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.9
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.9
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 45.6 = 12 * 2 * 1.9 
+  "map\\.string\\.fontsize\\.$t": 45.6
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 133 = 70 * 1.9; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_16-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_16-0.ini
@@ -1,0 +1,51 @@
+[context]
+user = "win7_magnifier_16-0"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 16.0
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 16.0
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 16.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 16.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 384 = 12 * 2 * 16.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 1120 = 70 * 16.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_16-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_16-0_sn.ini
@@ -1,0 +1,51 @@
+[context]
+user = "win7_magnifier_16-0_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 16.0
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 16.0
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 16.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 16.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 384 = 12 * 2 * 16.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 1120 = 70 * 16.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_2-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-0.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_2-0"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 2.0
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 200
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 2.0
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 2.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 2.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 48 = 12 * 2 * 2.0 
+  "map\\.string\\.fontsize\\.$t": 48
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 140 = 70 * 2.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_2-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-0_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_2-0_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 2.0
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 200
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 2.0
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 2.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 2.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 48 = 12 * 2 * 2.0 
+  "map\\.string\\.fontsize\\.$t": 48
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 140 = 70 * 2.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_2-1.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-1.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_2-1"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 2.1
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 210
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 2.1
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 2.1
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 2.1
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 50.4 = 12 * 2 * 2.1 
+  "map\\.string\\.fontsize\\.$t": 50.4
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 147 = 70 * 2.1; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_2-1_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-1_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_2-1_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 2.1
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 210
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 2.1
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 2.1
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 2.1
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 50.4 = 12 * 2 * 2.1 
+  "map\\.string\\.fontsize\\.$t": 50.4
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 147 = 70 * 2.1; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_2-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-2.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_2-2"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 2.2
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 220
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 2.2
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 2.2
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 2.2
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 52.8 = 12 * 2 * 2.2 
+  "map\\.string\\.fontsize\\.$t": 52.8
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 154 = 70 * 2.2; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 154
+

--- a/manualDataThirdPhase/win7_magnifier_2-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-2_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_2-2_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 2.2
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 220
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 2.2
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 2.2
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 2.2
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 52.8 = 12 * 2 * 2.2 
+  "map\\.string\\.fontsize\\.$t": 52.8
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 154 = 70 * 2.2; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 154
+

--- a/manualDataThirdPhase/win7_magnifier_2-3.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-3.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_2-3"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 2.3
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 230
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 2.3
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 2.3
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 2.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 55.2 = 12 * 2 * 2.3 
+  "map\\.string\\.fontsize\\.$t": 55.2
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 161 = 70 * 2.3; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_2-3_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-3_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_2-3_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 2.3
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 230
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 2.3
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 2.3
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 2.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 55.2 = 12 * 2 * 2.3 
+  "map\\.string\\.fontsize\\.$t": 55.2
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 161 = 70 * 2.3; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_2-4.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-4.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_2-4"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 2.4
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 240
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 2.4
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 2.4
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 2.4
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 57.6 = 12 * 2 * 2.4 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 168 = 70 * 2.4; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_2-4_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-4_sn.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_2-4_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 2.4
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 240
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 2.4
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 2.4
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 2.4
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 57.6 = 12 * 2 * 2.4 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 168 = 70 * 2.4; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_24-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_24-0.ini
@@ -1,0 +1,51 @@
+[context]
+user = "win7_magnifier_24-0"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 24.0
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 24.0
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 24.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 24.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 576 = 12 * 2 * 24.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 1680 = 70 * 24.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_24-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_24-0_sn.ini
@@ -1,0 +1,51 @@
+[context]
+user = "win7_magnifier_24-0_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 24.0
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 24.0
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 24.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 24.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 576 = 12 * 2 * 24.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 1680 = 70 * 24.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_32-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_32-0.ini
@@ -1,0 +1,52 @@
+[context]
+user = "win7_magnifier_32-0"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 32.0
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 32.0
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; 32.0 is the upper limit for the Gnome Magnifier
+  "mag-factor": 32.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 32.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 768 = 12 * 2 * 32.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 2240 = 70 * 32.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_32-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_32-0_sn.ini
@@ -1,0 +1,52 @@
+[context]
+user = "win7_magnifier_32-0_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 32.0
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 32.0
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; 32.0 is the upper limit for the Gnome Magnifier
+  "mag-factor": 32.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 32.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 768 = 12 * 2 * 32.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 2240 = 70 * 32.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_48-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_48-0.ini
@@ -1,0 +1,52 @@
+[context]
+user = "win7_magnifier_48-0"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 48.0
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 48.0
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; 32.0 is the upper limit for the Gnome Magnifier
+  "mag-factor": 32.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 48.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 1152 = 12 * 2 * 48.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 3360 = 70 * 48.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_48-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_48-0_sn.ini
@@ -1,0 +1,52 @@
+[context]
+user = "win7_magnifier_48-0_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 48.0
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 48.0
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; 32.0 is the upper limit for the Gnome Magnifier
+  "mag-factor": 32.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 48.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 1152 = 12 * 2 * 48.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 3360 = 70 * 48.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_60-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_60-0.ini
@@ -1,0 +1,53 @@
+[context]
+user = "win7_magnifier_60-0"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 60.0
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  ; 60.0 is the upper limit for the SuperNova Magnifier
+  "magnification": 60.0
+  "magnifierPosition": "FullScreen"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; 32.0 is the upper limit for the Gnome Magnifier
+  "mag-factor": 32.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+	"screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 60.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 1440 = 12 * 2 * 60.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 4200 = 70 * 60.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+

--- a/manualDataThirdPhase/win7_magnifier_60-0.ini~3~
+++ b/manualDataThirdPhase/win7_magnifier_60-0.ini~3~
@@ -1,0 +1,45 @@
+[context]
+user = "win7_magnifier_60-0"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  ; 60.0 is the upper limit for the SuperNova Magnifier
+  "magnification": 60.0
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; 32.0 is the upper limit for the Gnome Magnifier
+  "mag-factor": 32.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+	"screen-magnifier-enabled": true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 60.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 1440 = 12 * 2 * 60.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 4200 = 70 * 60.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105

--- a/manualDataThirdPhase/win7_magnifier_60-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_60-0_sn.ini
@@ -1,0 +1,53 @@
+[context]
+user = "win7_magnifier_60-0_sn"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 60.0
+  magnifierPosition = "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
+  "MagnificationMode": 2
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  ; 60.0 is the upper limit for the SuperNova Magnifier
+  "magnification": 60.0
+  "magnifierPosition": "FullScreen"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; 32.0 is the upper limit for the Gnome Magnifier
+  "mag-factor": 32.0
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+	"screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 60.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 1440 = 12 * 2 * 60.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 4200 = 70 * 60.0; max iconsize = 105
+  "map\\.string\\.iconsize\\.$t": 105
+


### PR DESCRIPTION
GPII-1112: training data for the Windows magnifier and the magnifier in the SuperNova Access Suite (enabling one, disabling the other). 
