### PR TITLE
GPII-1112: Magnifier: lens mode (Windows, SuperNova)

### DIFF
--- a/manualDataThirdPhase/win7_magnifier_lens_1-1.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-1.ini
@@ -1,0 +1,53 @@
+[context]
+user = "win7_magnifier_lens_1-1"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.1
+  magnifierPosition = "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 110
+  "MagnificationMode": 3
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  ; SuperNova magnification starts at 1.2, not at 1.1
+  "magnification": 1.2
+  "magnifierPosition": "Lens"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.1
+  ; to enable lens mode, screen-position must be different from "full-screen"
+  "screen-position": "top-half"
+  "lens-mode": true
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.1
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 26.4 = 12 * 2 * 1.1 
+  "map\\.string\\.fontsize\\.$t": 26.4
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 84 = 70 * 1.2
+  "map\\.string\\.iconsize\\.$t": 84
+

--- a/manualDataThirdPhase/win7_magnifier_lens_1-1_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-1_sn.ini
@@ -1,31 +1,33 @@
 [context]
-user = "win7_magnifier_lens_1-5"
+user = "win7_magnifier_lens_1-1_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 1.5
+  magnification = 1.1
   magnifierPosition = "Lens"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  "Magnification": 150
+  "Magnification": 110
   "MagnificationMode": 3
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
-  "magnification": 1.5
+  ; SuperNova magnification starts at 1.2, not at 1.1
+  "magnification": 1.2
   "magnifierPosition": "Lens"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  "mag-factor": 1.5
+  "mag-factor": 1.1
+  ; to enable lens mode, screen-position must be different from "full-screen"
   "screen-position": "top-half"
   "lens-mode": true
   "mouse-tracking": "proportional"
@@ -38,12 +40,14 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  "fontScale": 1.5
+  "fontScale": 1.1
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 36 = 12 * 2 * 1.5 
-  "map\\.string\\.fontsize\\.$t": 36
-  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+  ; 26.4 = 12 * 2 * 1.1 
+  "map\\.string\\.fontsize\\.$t": 26.4
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 84 = 70 * 1.2
+  "map\\.string\\.iconsize\\.$t": 84
 

--- a/manualDataThirdPhase/win7_magnifier_lens_1-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-2.ini
@@ -1,0 +1,50 @@
+[context]
+user = "win7_magnifier_lens_1-2"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.2
+  magnifierPosition = "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 120
+  "MagnificationMode": 3
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.2
+  "magnifierPosition": "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.2
+  "screen-position": "top-half"
+  "lens-mode": true
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.2
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 28.8 = 12 * 2 * 1.2
+  "map\\.string\\.fontsize\\.$t": 28.8
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 84 = 70 * 1.2
+  "map\\.string\\.iconsize\\.$t": 84
+

--- a/manualDataThirdPhase/win7_magnifier_lens_1-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
   "magnification": 1.2
   "magnifierPosition": "Lens"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lens_1-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lens_1-5"
+user = "win7_magnifier_lens_1-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 1.5
+  magnification = 1.2
   magnifierPosition = "Lens"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  "Magnification": 150
+  "Magnification": 120
   "MagnificationMode": 3
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
-  "magnification": 1.5
+  "magnification": 1.2
   "magnifierPosition": "Lens"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  "mag-factor": 1.5
+  "mag-factor": 1.2
   "screen-position": "top-half"
   "lens-mode": true
   "mouse-tracking": "proportional"
@@ -38,12 +38,14 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  "fontScale": 1.5
+  "fontScale": 1.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 36 = 12 * 2 * 1.5 
-  "map\\.string\\.fontsize\\.$t": 36
-  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+  ; 28.8 = 12 * 2 * 1.2
+  "map\\.string\\.fontsize\\.$t": 28.8
+  ; @@iconsize scale to be confirmed by Omnitor
+  ; 84 = 70 * 1.2
+  "map\\.string\\.iconsize\\.$t": 84
 

--- a/manualDataThirdPhase/win7_magnifier_lens_1-3.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-3.ini
@@ -1,0 +1,48 @@
+[context]
+user = "win7_magnifier_lens_1-3"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.3
+  magnifierPosition = "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 130
+  "MagnificationMode": 3
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.3
+  "magnifierPosition": "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.3
+  "screen-position": "top-half"
+  "lens-mode": true
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 31.2 = 12 * 2 * 1.3 
+  "map\\.string\\.fontsize\\.$t": 31.2
+  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+

--- a/manualDataThirdPhase/win7_magnifier_lens_1-3.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-3.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
   "magnification": 1.3
   "magnifierPosition": "Lens"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lens_1-3_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-3_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lens_1-5"
+user = "win7_magnifier_lens_1-3_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 1.5
+  magnification = 1.3
   magnifierPosition = "Lens"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  "Magnification": 150
+  "Magnification": 130
   "MagnificationMode": 3
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
-  "magnification": 1.5
+  "magnification": 1.3
   "magnifierPosition": "Lens"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  "mag-factor": 1.5
+  "mag-factor": 1.3
   "screen-position": "top-half"
   "lens-mode": true
   "mouse-tracking": "proportional"
@@ -38,12 +38,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  "fontScale": 1.5
+  "fontScale": 1.3
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 36 = 12 * 2 * 1.5 
-  "map\\.string\\.fontsize\\.$t": 36
+  ; 31.2 = 12 * 2 * 1.3 
+  "map\\.string\\.fontsize\\.$t": 31.2
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lens_1-5.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-5.ini
@@ -1,0 +1,48 @@
+[context]
+user = "win7_magnifier_lens_1-5"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.5
+  magnifierPosition = "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 150
+  "MagnificationMode": 3
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.5
+  "magnifierPosition": "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.5
+  "screen-position": "top-half"
+  "lens-mode": true
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.5
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 36 = 12 * 2 * 1.5 
+  "map\\.string\\.fontsize\\.$t": 36
+  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+

--- a/manualDataThirdPhase/win7_magnifier_lens_1-5_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-5_sn.ini
@@ -1,5 +1,5 @@
 [context]
-user = "win7_magnifier_lens_1-5"
+user = "win7_magnifier_lens_1-5_sn"
 os = "windows"
 
 [preferences]
@@ -15,13 +15,13 @@ app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
   "magnification": 1.5
   "magnifierPosition": "Lens"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lens_1-75.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-75.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
   "magnification": 1.75
   "magnifierPosition": "Lens"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lens_1-75.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-75.ini
@@ -1,0 +1,48 @@
+[context]
+user = "win7_magnifier_lens_1-75"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 1.75
+  magnifierPosition = "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 175
+  "MagnificationMode": 3
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 1.75
+  "magnifierPosition": "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 1.75
+  "screen-position": "top-half"
+  "lens-mode": true
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 1.75
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 42 = 12 * 2 * 1.75 
+  "map\\.string\\.fontsize\\.$t": 42
+  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+

--- a/manualDataThirdPhase/win7_magnifier_lens_1-75_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_1-75_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lens_1-5"
+user = "win7_magnifier_lens_1-75_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 1.5
+  magnification = 1.75
   magnifierPosition = "Lens"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  "Magnification": 150
+  "Magnification": 175
   "MagnificationMode": 3
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
-  "magnification": 1.5
+  "magnification": 1.75
   "magnifierPosition": "Lens"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  "mag-factor": 1.5
+  "mag-factor": 1.75
   "screen-position": "top-half"
   "lens-mode": true
   "mouse-tracking": "proportional"
@@ -38,12 +38,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  "fontScale": 1.5
+  "fontScale": 1.75
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 36 = 12 * 2 * 1.5 
-  "map\\.string\\.fontsize\\.$t": 36
+  ; 42 = 12 * 2 * 1.75 
+  "map\\.string\\.fontsize\\.$t": 42
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lens_16-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_16-0.ini
@@ -22,6 +22,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
   "magnification": 16.0
   "magnifierPosition": "Lens"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lens_16-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_16-0.ini
@@ -1,0 +1,49 @@
+[context]
+user = "win7_magnifier_lens_16-0"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 16.0
+  magnifierPosition = "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
+  "MagnificationMode": 3
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 16.0
+  "magnifierPosition": "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 16.0
+  "screen-position": "top-half"
+  "lens-mode": true
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 16.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 384 = 12 * 2 * 16.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+

--- a/manualDataThirdPhase/win7_magnifier_lens_16-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_16-0_sn.ini
@@ -1,31 +1,32 @@
 [context]
-user = "win7_magnifier_lens_1-5"
+user = "win7_magnifier_lens_16-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 1.5
+  magnification = 16.0
   magnifierPosition = "Lens"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  "Magnification": 150
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
   "MagnificationMode": 3
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
-  "magnification": 1.5
+  "magnification": 16.0
   "magnifierPosition": "Lens"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  "mag-factor": 1.5
+  "mag-factor": 16.0
   "screen-position": "top-half"
   "lens-mode": true
   "mouse-tracking": "proportional"
@@ -38,12 +39,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  "fontScale": 1.5
+  "fontScale": 16.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 36 = 12 * 2 * 1.5 
-  "map\\.string\\.fontsize\\.$t": 36
+  ; 384 = 12 * 2 * 16.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lens_2-25.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_2-25.ini
@@ -1,0 +1,48 @@
+[context]
+user = "win7_magnifier_lens_2-25"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 2.25
+  magnifierPosition = "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 225
+  "MagnificationMode": 3
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 2.25
+  "magnifierPosition": "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 2.25
+  "screen-position": "top-half"
+  "lens-mode": true
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 2.25
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 54 = 12 * 2 * 2.25 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+

--- a/manualDataThirdPhase/win7_magnifier_lens_2-25.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_2-25.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
   "magnification": 2.25
   "magnifierPosition": "Lens"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lens_2-25_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_2-25_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lens_1-5"
+user = "win7_magnifier_lens_2-25_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 1.5
+  magnification = 2.25
   magnifierPosition = "Lens"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  "Magnification": 150
+  "Magnification": 225
   "MagnificationMode": 3
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
-  "magnification": 1.5
+  "magnification": 2.25
   "magnifierPosition": "Lens"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  "mag-factor": 1.5
+  "mag-factor": 2.25
   "screen-position": "top-half"
   "lens-mode": true
   "mouse-tracking": "proportional"
@@ -38,12 +38,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  "fontScale": 1.5
+  "fontScale": 2.25
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 36 = 12 * 2 * 1.5 
-  "map\\.string\\.fontsize\\.$t": 36
+  ; 54 = 12 * 2 * 2.25 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lens_2-5.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_2-5.ini
@@ -1,0 +1,48 @@
+[context]
+user = "win7_magnifier_lens_2-5"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 2.5
+  magnifierPosition = "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 250
+  "MagnificationMode": 3
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 2.5
+  "magnifierPosition": "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 2.5
+  "screen-position": "top-half"
+  "lens-mode": true
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 2.5
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 60 = 12 * 2 * 2.5 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+

--- a/manualDataThirdPhase/win7_magnifier_lens_2-5.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_2-5.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
   "magnification": 2.5
   "magnifierPosition": "Lens"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lens_2-5_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_2-5_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lens_1-5"
+user = "win7_magnifier_lens_2-5_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 1.5
+  magnification = 2.5
   magnifierPosition = "Lens"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  "Magnification": 150
+  "Magnification": 250
   "MagnificationMode": 3
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
-  "magnification": 1.5
+  "magnification": 2.5
   "magnifierPosition": "Lens"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  "mag-factor": 1.5
+  "mag-factor": 2.5
   "screen-position": "top-half"
   "lens-mode": true
   "mouse-tracking": "proportional"
@@ -38,12 +38,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  "fontScale": 1.5
+  "fontScale": 2.5
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 36 = 12 * 2 * 1.5 
-  "map\\.string\\.fontsize\\.$t": 36
+  ; 60 = 12 * 2 * 2.5 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lens_24-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_24-0_sn.ini
@@ -1,31 +1,32 @@
 [context]
-user = "win7_magnifier_lens_1-5"
+user = "win7_magnifier_lens_24-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 1.5
+  magnification = 24.0
   magnifierPosition = "Lens"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  "Magnification": 150
+  ; 1600 is the upper limit for the Windows Magnifier
+  "Magnification": 1600
   "MagnificationMode": 3
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
-  "magnification": 1.5
+  "magnification": 24.0
   "magnifierPosition": "Lens"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  "mag-factor": 1.5
+  "mag-factor": 24.0
   "screen-position": "top-half"
   "lens-mode": true
   "mouse-tracking": "proportional"
@@ -38,12 +39,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  "fontScale": 1.5
+  "fontScale": 24.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 36 = 12 * 2 * 1.5 
-  "map\\.string\\.fontsize\\.$t": 36
+  ; 576 = 12 * 2 * 24.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lens_3-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_3-0.ini
@@ -1,0 +1,48 @@
+[context]
+user = "win7_magnifier_lens_3-0"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 3.0
+  magnifierPosition = "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 300
+  "MagnificationMode": 3
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 3.0
+  "magnifierPosition": "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 3.0
+  "screen-position": "top-half"
+  "lens-mode": true
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 3.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 72 = 12 * 2 * 3.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+

--- a/manualDataThirdPhase/win7_magnifier_lens_3-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_3-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
   "magnification": 3.0
   "magnifierPosition": "Lens"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lens_3-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_3-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lens_1-5"
+user = "win7_magnifier_lens_3-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 1.5
+  magnification = 3.0
   magnifierPosition = "Lens"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  "Magnification": 150
+  "Magnification": 300
   "MagnificationMode": 3
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
-  "magnification": 1.5
+  "magnification": 3.0
   "magnifierPosition": "Lens"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  "mag-factor": 1.5
+  "mag-factor": 3.0
   "screen-position": "top-half"
   "lens-mode": true
   "mouse-tracking": "proportional"
@@ -38,12 +38,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  "fontScale": 1.5
+  "fontScale": 3.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 36 = 12 * 2 * 1.5 
-  "map\\.string\\.fontsize\\.$t": 36
+  ; 72 = 12 * 2 * 3.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lens_4-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_4-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
   "magnification": 4.0
   "magnifierPosition": "Lens"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lens_4-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_4-0.ini
@@ -1,0 +1,48 @@
+[context]
+user = "win7_magnifier_lens_4-0"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 4.0
+  magnifierPosition = "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 400
+  "MagnificationMode": 3
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 4.0
+  "magnifierPosition": "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 4.0
+  "screen-position": "top-half"
+  "lens-mode": true
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 4.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+

--- a/manualDataThirdPhase/win7_magnifier_lens_4-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_4-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lens_1-5"
+user = "win7_magnifier_lens_4-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 1.5
+  magnification = 4.0
   magnifierPosition = "Lens"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  "Magnification": 150
+  "Magnification": 400
   "MagnificationMode": 3
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
-  "magnification": 1.5
+  "magnification": 4.0
   "magnifierPosition": "Lens"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  "mag-factor": 1.5
+  "mag-factor": 4.0
   "screen-position": "top-half"
   "lens-mode": true
   "mouse-tracking": "proportional"
@@ -38,12 +38,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  "fontScale": 1.5
+  "fontScale": 4.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 36 = 12 * 2 * 1.5 
-  "map\\.string\\.fontsize\\.$t": 36
+  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lens_8-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_8-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
   "magnification": 8.0
   "magnifierPosition": "Lens"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lens_8-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_8-0.ini
@@ -1,0 +1,48 @@
+[context]
+user = "win7_magnifier_lens_8-0"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  magnifierEnabled = true
+  magnification = 8.0
+  magnifierPosition = "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  "Magnification": 800
+  "MagnificationMode": 3
+  "FollowFocus": 1
+  "FollowCaret": 1
+  "FollowMouse": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "magnifierEnabled": true
+  "magnification": 8.0
+  "magnifierPosition": "Lens"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  "mag-factor": 8.0
+  "screen-position": "top-half"
+  "lens-mode": true
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; as multiple of 12 points
+  "fontScale": 8.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; No magnification supported in Pilot 2, so using font scale as a fallback
+  ; 192 = 12 * 2 * 8.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
+  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+

--- a/manualDataThirdPhase/win7_magnifier_lens_8-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lens_8-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lens_1-5"
+user = "win7_magnifier_lens_8-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 1.5
+  magnification = 8.0
   magnifierPosition = "Lens"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  "Magnification": 150
+  "Magnification": 800
   "MagnificationMode": 3
   "FollowFocus": 1
   "FollowCaret": 1
   "FollowMouse": 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnifierEnabled": true
-  "magnification": 1.5
+  "magnification": 8.0
   "magnifierPosition": "Lens"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  "mag-factor": 1.5
+  "mag-factor": 8.0
   "screen-position": "top-half"
   "lens-mode": true
   "mouse-tracking": "proportional"
@@ -38,12 +38,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  "fontScale": 1.5
+  "fontScale": 8.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 36 = 12 * 2 * 1.5 
-  "map\\.string\\.fontsize\\.$t": 36
+  ; 192 = 12 * 2 * 8.0 but upper limit for font size = 50
+  "map\\.string\\.fontsize\\.$t": 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 


### PR DESCRIPTION
GPII-1112: Training data for magnifier in lens mode. On Windows, only the Windows Magnifier or only the SuperNova magnifier should be enabled. 
