### PR TITLE
GPII-1112: avoid launching both WinMag and SuperNova Mag

### DIFF
--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_1-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_1-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 1.2
   magnifierPosition = "BottomHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_1-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_1-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_bottomhalf_2-0"
+user = "win7_magnifier_bottomhalf_1-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.2
   magnifierPosition = "BottomHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 120
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.2
   magnifierPosition = "BottomHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 1.2
   screen-position = "bottom-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 1.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 28.8 = 12 * 2 * 1.2 
+  map\\.string\\.fontsize\\.$t = 28.8
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_1-6.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_1-6.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 1.6
   magnifierPosition = "BottomHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_1-6_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_1-6_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_bottomhalf_2-0"
+user = "win7_magnifier_bottomhalf_1-6_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.6
   magnifierPosition = "BottomHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 160
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.6
   magnifierPosition = "BottomHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 1.6
   screen-position = "bottom-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 1.6
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 38.4 = 12 * 2 * 1.6 
+  map\\.string\\.fontsize\\.$t = 38.4
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_1-8.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_1-8.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 1.8
   magnifierPosition = "BottomHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_1-8_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_1-8_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_bottomhalf_2-0"
+user = "win7_magnifier_bottomhalf_1-8_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.8
   magnifierPosition = "BottomHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 180
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.8
   magnifierPosition = "BottomHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 1.8
   screen-position = "bottom-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 1.8
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 43.2 = 12 * 2 * 1.8 
+  map\\.string\\.fontsize\\.$t = 43.2
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_16-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_16-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 16.0
   magnifierPosition = "BottomHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_16-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_16-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_bottomhalf_2-0"
+user = "win7_magnifier_bottomhalf_16-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 16.0
   magnifierPosition = "BottomHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 1600
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 16.0
   magnifierPosition = "BottomHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 16.0
   screen-position = "bottom-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 16.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 384 = 12 * 2 * 16.0 but upper limit for font size = 50
+  map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_2-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_2-0_sn.ini
@@ -1,5 +1,5 @@
 [context]
-user = "win7_magnifier_bottomhalf_2-0"
+user = "win7_magnifier_bottomhalf_2-0_sn"
 os = "windows"
 
 [preferences]
@@ -15,13 +15,13 @@ app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 2.0
   magnifierPosition = "BottomHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_2-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_2-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 2.2
   magnifierPosition = "BottomHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_2-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_2-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_bottomhalf_2-0"
+user = "win7_magnifier_bottomhalf_2-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 2.2
   magnifierPosition = "BottomHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 220
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 2.2
   magnifierPosition = "BottomHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 2.2
   screen-position = "bottom-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 2.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 52.8 = 12 * 2 * 2.2 
+  map\\.string\\.fontsize\\.$t = 52.8
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_2-6.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_2-6.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 2.6
   magnifierPosition = "BottomHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_2-6_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_2-6_sn.ini
@@ -1,48 +1,48 @@
 [context]
-user = "win7_magnifier_bottomhalf_2-0"
+user = "win7_magnifier_bottomhalf_2-6_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.2
   magnifierPosition = "BottomHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 260
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 2.6
   magnifierPosition = "BottomHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 2.6
   screen-position = "bottom-half"
   mouse-tracking = "proportional"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
-  screen-magnifier-enabled = true
+	screen-magnifier-enabled = true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 2.6
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 62.4 = 12 * 2 * 2.6 but upper limit for font size = 50
+  map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_3-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_3-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 3.2
   magnifierPosition = "BottomHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_3-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_3-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_bottomhalf_2-0"
+user = "win7_magnifier_bottomhalf_3-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 3.2
   magnifierPosition = "BottomHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 320
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 3.2
   magnifierPosition = "BottomHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 3.2
   screen-position = "bottom-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 3.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 76.8 = 12 * 2 * 3.2 but upper limit for font size = 50
+  map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_4-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_4-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 4.0
   magnifierPosition = "BottomHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_4-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_4-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_bottomhalf_2-0"
+user = "win7_magnifier_bottomhalf_4-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 4.0
   magnifierPosition = "BottomHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 400
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 4.0
   magnifierPosition = "BottomHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 4.0
   screen-position = "bottom-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 4.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
-  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
+  map\\.string\\.fontsize\\.$t = 50
+  ; @@iconsize scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_6-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_6-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 6.0
   magnifierPosition = "BottomHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_bottomhalf_6-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_bottomhalf_6-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_bottomhalf_2-0"
+user = "win7_magnifier_bottomhalf_6-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 6.0
   magnifierPosition = "BottomHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 600
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 6.0
   magnifierPosition = "BottomHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 6.0
   screen-position = "bottom-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 6.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 144 = 12 * 2 * 6.0 but upper limit for font size = 50
+  map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_1-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_1-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 1.2
   magnifierPosition = "LeftHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_1-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_1-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lefthalf_4-0"
+user = "win7_magnifier_lefthalf_1-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 1.2
   magnifierPosition = "LeftHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 400
+  Magnification = 120
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 1.2
   magnifierPosition = "LeftHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 4.0
+  mag-factor = 1.2
   screen-position = "left-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 4.0
+  fontScale = 1.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
-  map\\.string\\.fontsize\\.$t = 50
+  ; 28.8 = 12 * 2 * 1.2 
+  map\\.string\\.fontsize\\.$t = 28.8
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_1-6.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_1-6.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 1.6
   magnifierPosition = "LeftHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_1-6_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_1-6_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lefthalf_4-0"
+user = "win7_magnifier_lefthalf_1-6_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 1.6
   magnifierPosition = "LeftHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 400
+  Magnification = 160
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 1.6
   magnifierPosition = "LeftHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 4.0
+  mag-factor = 1.6
   screen-position = "left-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 4.0
+  fontScale = 1.6
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
-  map\\.string\\.fontsize\\.$t = 50
+  ; 38.4 = 12 * 2 * 1.6 
+  map\\.string\\.fontsize\\.$t = 38.4
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_1-8.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_1-8.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 1.8
   magnifierPosition = "LeftHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_1-8_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_1-8_sn.ini
@@ -1,31 +1,32 @@
 [context]
-user = "win7_magnifier_lefthalf_4-0"
+user = "win7_magnifier_lefthalf_1-8_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 1.8
   magnifierPosition = "LeftHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 400
+  Magnification = 180
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 1.8
   magnifierPosition = "LeftHalf"
   _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 4.0
+  mag-factor = 1.8
   screen-position = "left-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +38,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 4.0
+  fontScale = 1.8
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
-  map\\.string\\.fontsize\\.$t = 50
+  ; 43.2 = 12 * 2 * 1.8 
+  map\\.string\\.fontsize\\.$t = 43.2
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_16-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_16-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 16.0
   magnifierPosition = "LeftHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_16-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_16-0_sn.ini
@@ -1,33 +1,34 @@
 [context]
-user = "win7_magnifier_lefthalf_4-0"
+user = "win7_magnifier_lefthalf_16-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 16.0
   magnifierPosition = "LeftHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 400
+  Magnification = 1600
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 16.0
   magnifierPosition = "LeftHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 4.0
+  mag-factor = 16.0
   screen-position = "left-half"
   mouse-tracking = "proportional"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
@@ -37,12 +38,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 4.0
+  fontScale = 16.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
+  ; 384 = 12 * 2 * 16.0 but upper limit for font size = 50
   map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_2-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_2-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 2.0
   magnifierPosition = "LeftHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_2-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_2-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lefthalf_4-0"
+user = "win7_magnifier_lefthalf_2-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 2.0
   magnifierPosition = "LeftHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 400
+  Magnification = 200
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 2.0
   magnifierPosition = "LeftHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 4.0
+  mag-factor = 2.0
   screen-position = "left-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 4.0
+  fontScale = 2.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
-  map\\.string\\.fontsize\\.$t = 50
+  ; 48 = 12 * 2 * 2.0 
+  map\\.string\\.fontsize\\.$t = 48
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_2-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_2-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 2.2
   magnifierPosition = "LeftHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_2-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_2-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lefthalf_4-0"
+user = "win7_magnifier_lefthalf_2-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 2.2
   magnifierPosition = "LeftHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 400
+  Magnification = 220
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 2.2
   magnifierPosition = "LeftHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 4.0
+  mag-factor = 2.2
   screen-position = "left-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 4.0
+  fontScale = 2.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
-  map\\.string\\.fontsize\\.$t = 50
+  ; 52.8 = 12 * 2 * 2.2 
+  map\\.string\\.fontsize\\.$t = 52.8
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_2-6.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_2-6.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 2.6
   magnifierPosition = "LeftHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_2-6_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_2-6_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lefthalf_4-0"
+user = "win7_magnifier_lefthalf_2-6_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 2.6
   magnifierPosition = "LeftHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 400
+  Magnification = 260
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 2.6
   magnifierPosition = "LeftHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 4.0
+  mag-factor = 2.6
   screen-position = "left-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 4.0
+  fontScale = 2.6
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
+  ; 62.4 = 12 * 2 * 2.6 but upper limit for font size = 50
   map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_3-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_3-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 3.2
   magnifierPosition = "LeftHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_3-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_3-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lefthalf_4-0"
+user = "win7_magnifier_lefthalf_3-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 3.2
   magnifierPosition = "LeftHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 400
+  Magnification = 320
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 3.2
   magnifierPosition = "LeftHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 4.0
+  mag-factor = 3.2
   screen-position = "left-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 4.0
+  fontScale = 3.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
+  ; 76.8 = 12 * 2 * 3.2 but upper limit for font size = 50
   map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_4-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_4-0_sn.ini
@@ -1,5 +1,5 @@
 [context]
-user = "win7_magnifier_lefthalf_4-0"
+user = "win7_magnifier_lefthalf_4-0_sn"
 os = "windows"
 
 [preferences]
@@ -15,13 +15,13 @@ app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 4.0
   magnifierPosition = "LeftHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_6-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_6-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 6.0
   magnifierPosition = "LeftHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_lefthalf_6-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_lefthalf_6-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_lefthalf_4-0"
+user = "win7_magnifier_lefthalf_6-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 6.0
   magnifierPosition = "LeftHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 400
+  Magnification = 600
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 4.0
+  magnification = 6.0
   magnifierPosition = "LeftHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 4.0
+  mag-factor = 6.0
   screen-position = "left-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 4.0
+  fontScale = 6.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
+  ; 144 = 12 * 2 * 6.0 but upper limit for font size = 50
   map\\.string\\.fontsize\\.$t = 50
-  ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
+  ; @@iconsize scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_righthalf_1-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_1-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 1.2
   magnifierPosition = "RightHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_righthalf_1-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_1-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_righthalf_6-0"
+user = "win7_magnifier_righthalf_1-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 1.2
   magnifierPosition = "RightHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 600
+  Magnification = 120
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 1.2
   magnifierPosition = "RightHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 6.0
+  mag-factor = 1.2
   screen-position = "right-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 6.0
+  fontScale = 1.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 144 = 12 * 2 * 6.0 but upper limit for font size = 50
-  map\\.string\\.fontsize\\.$t = 50
+  ; 28.8 = 12 * 2 * 1.2 
+  map\\.string\\.fontsize\\.$t = 28.8
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_righthalf_1-6.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_1-6.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 1.6
   magnifierPosition = "RightHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_righthalf_1-6_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_1-6_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_righthalf_6-0"
+user = "win7_magnifier_righthalf_1-6_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 1.6
   magnifierPosition = "RightHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 600
+  Magnification = 160
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 1.6
   magnifierPosition = "RightHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 6.0
+  mag-factor = 1.6
   screen-position = "right-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 6.0
+  fontScale = 1.6
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 144 = 12 * 2 * 6.0 but upper limit for font size = 50
-  map\\.string\\.fontsize\\.$t = 50
+  ; 38.4 = 12 * 2 * 1.6 
+  map\\.string\\.fontsize\\.$t = 38.4
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_righthalf_1-8.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_1-8.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 1.8
   magnifierPosition = "RightHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_righthalf_1-8_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_1-8_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_righthalf_6-0"
+user = "win7_magnifier_righthalf_1-8_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 1.2
   magnifierPosition = "RightHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 600
+  Magnification = 180
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 1.8
   magnifierPosition = "RightHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 6.0
+  mag-factor = 1.8
   screen-position = "right-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 6.0
+  fontScale = 1.8
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 144 = 12 * 2 * 6.0 but upper limit for font size = 50
-  map\\.string\\.fontsize\\.$t = 50
+  ; 43.2 = 12 * 2 * 1.8 
+  map\\.string\\.fontsize\\.$t = 43.2
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_righthalf_16-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_16-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 16.0
   magnifierPosition = "RightHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_righthalf_16-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_16-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_righthalf_6-0"
+user = "win7_magnifier_righthalf_16-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 16.0
   magnifierPosition = "RightHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 600
+  Magnification = 1600
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 16.0
   magnifierPosition = "RightHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 6.0
+  mag-factor = 16.0
   screen-position = "right-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 6.0
+  fontScale = 16.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 144 = 12 * 2 * 6.0 but upper limit for font size = 50
+  ; 384 = 12 * 2 * 16.0 but upper limit for font size = 50
   map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_righthalf_2-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_2-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 2.0
   magnifierPosition = "RightHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_righthalf_2-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_2-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_righthalf_6-0"
+user = "win7_magnifier_righthalf_2-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 2.0
   magnifierPosition = "RightHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 600
+  Magnification = 200
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 2.0
   magnifierPosition = "RightHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 6.0
+  mag-factor = 2.0
   screen-position = "right-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 6.0
+  fontScale = 2.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 144 = 12 * 2 * 6.0 but upper limit for font size = 50
-  map\\.string\\.fontsize\\.$t = 50
+  ; 48 = 12 * 2 * 2.0 
+  map\\.string\\.fontsize\\.$t = 48
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_righthalf_2-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_2-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 2.2
   magnifierPosition = "RightHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_righthalf_2-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_2-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_righthalf_6-0"
+user = "win7_magnifier_righthalf_2-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 2.2
   magnifierPosition = "RightHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 600
+  Magnification = 220
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 2.2
   magnifierPosition = "RightHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 6.0
+  mag-factor = 2.2
   screen-position = "right-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 6.0
+  fontScale = 2.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 144 = 12 * 2 * 6.0 but upper limit for font size = 50
-  map\\.string\\.fontsize\\.$t = 50
+  ; 52.8 = 12 * 2 * 2.2 
+  map\\.string\\.fontsize\\.$t = 52.8
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_righthalf_2-6.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_2-6.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 2.6
   magnifierPosition = "RightHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_righthalf_2-6_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_2-6_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_righthalf_6-0"
+user = "win7_magnifier_righthalf_2-6_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 2.6
   magnifierPosition = "RightHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 600
+  Magnification = 260
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 2.6
   magnifierPosition = "RightHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 6.0
+  mag-factor = 2.6
   screen-position = "right-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 6.0
+  fontScale = 2.6
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 144 = 12 * 2 * 6.0 but upper limit for font size = 50
+  ; 62.4 = 12 * 2 * 2.6 but upper limit for font size = 50
   map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_righthalf_3-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_3-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 3.2
   magnifierPosition = "RightHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_righthalf_3-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_3-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_righthalf_6-0"
+user = "win7_magnifier_righthalf_3-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 3.2
   magnifierPosition = "RightHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 600
+  Magnification = 320
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 3.2
   magnifierPosition = "RightHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 6.0
+  mag-factor = 3.2
   screen-position = "right-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 6.0
+  fontScale = 3.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 144 = 12 * 2 * 6.0 but upper limit for font size = 50
+  ; 76.8 = 12 * 2 * 3.2 but upper limit for font size = 50
   map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_righthalf_4-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_4-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 4.0
   magnifierPosition = "RightHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_righthalf_4-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_4-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_righthalf_6-0"
+user = "win7_magnifier_righthalf_4-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 4.0
   magnifierPosition = "RightHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 600
+  Magnification = 400
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 6.0
+  magnification = 4.0
   magnifierPosition = "RightHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 6.0
+  mag-factor = 4.0
   screen-position = "right-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 6.0
+  fontScale = 4.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 144 = 12 * 2 * 6.0 but upper limit for font size = 50
+  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
   map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_righthalf_6-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_righthalf_6-0_sn.ini
@@ -1,5 +1,5 @@
 [context]
-user = "win7_magnifier_righthalf_6-0"
+user = "win7_magnifier_righthalf_6-0_sn"
 os = "windows"
 
 [preferences]
@@ -15,13 +15,13 @@ app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 6.0
   magnifierPosition = "RightHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_tophalf_1-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_1-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 1.2
   magnifierPosition = "TopHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_tophalf_1-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_1-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_tophalf_2-0"
+user = "win7_magnifier_tophalf_1-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.2
   magnifierPosition = "TopHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 120
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.2
   magnifierPosition = "TopHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 1.2
   screen-position = "top-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 1.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 28.8 = 12 * 2 * 1.2 
+  map\\.string\\.fontsize\\.$t = 28.8
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_tophalf_1-6.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_1-6.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 1.6
   magnifierPosition = "TopHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_tophalf_1-6_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_1-6_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_tophalf_2-0"
+user = "win7_magnifier_tophalf_1-6_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.6
   magnifierPosition = "TopHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 160
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.6
   magnifierPosition = "TopHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 1.6
   screen-position = "top-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 1.6
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 38.4 = 12 * 2 * 1.6 
+  map\\.string\\.fontsize\\.$t = 38.4
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_tophalf_1-8.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_1-8.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 1.8
   magnifierPosition = "TopHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_tophalf_1-8_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_1-8_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_tophalf_2-0"
+user = "win7_magnifier_tophalf_1-8_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.8
   magnifierPosition = "TopHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 180
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 1.8
   magnifierPosition = "TopHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 1.8
   screen-position = "top-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 1.8
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 43.2 = 12 * 2 * 1.8 
+  map\\.string\\.fontsize\\.$t = 43.2
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_tophalf_16-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_16-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 16.0
   magnifierPosition = "TopHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_tophalf_16-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_16-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_tophalf_2-0"
+user = "win7_magnifier_tophalf_16-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 16.0
   magnifierPosition = "TopHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 1600
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 16.0
   magnifierPosition = "TopHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 16.0
   screen-position = "top-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 16.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 384 = 12 * 2 * 16.0 but upper limit for font size = 50
+  map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_tophalf_2-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_2-0_sn.ini
@@ -1,5 +1,5 @@
 [context]
-user = "win7_magnifier_tophalf_2-0"
+user = "win7_magnifier_tophalf_2-0_sn"
 os = "windows"
 
 [preferences]
@@ -15,13 +15,13 @@ app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 2.0
   magnifierPosition = "TopHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_tophalf_2-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_2-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 2.2
   magnifierPosition = "TopHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_tophalf_2-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_2-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_tophalf_2-0"
+user = "win7_magnifier_tophalf_2-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 2.2
   magnifierPosition = "TopHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 220
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 2.2
   magnifierPosition = "TopHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 2.2
   screen-position = "top-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 2.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 52.8 = 12 * 2 * 2.2 
+  map\\.string\\.fontsize\\.$t = 52.8
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_tophalf_2-6.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_2-6.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 2.6
   magnifierPosition = "TopHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_tophalf_2-6_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_2-6_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_tophalf_2-0"
+user = "win7_magnifier_tophalf_2-6_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 2.6
   magnifierPosition = "TopHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 260
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 2.6
   magnifierPosition = "TopHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 2.6
   screen-position = "top-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 2.6
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 62.4 = 12 * 2 * 2.6 but upper limit for font size = 50
+  map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_tophalf_3-2.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_3-2.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 3.2
   magnifierPosition = "TopHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_tophalf_3-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_3-2_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_tophalf_2-0"
+user = "win7_magnifier_tophalf_3-2_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 3.2
   magnifierPosition = "TopHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 320
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 3.2
   magnifierPosition = "TopHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 3.2
   screen-position = "top-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 3.2
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 76.8 = 12 * 2 * 3.2 but upper limit for font size = 50
+  map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_tophalf_4-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_4-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 4.0
   magnifierPosition = "TopHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_tophalf_4-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_4-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_tophalf_2-0"
+user = "win7_magnifier_tophalf_4-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 4.0
   magnifierPosition = "TopHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 400
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 4.0
   magnifierPosition = "TopHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 4.0
   screen-position = "top-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 4.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 96 = 12 * 2 * 4.0 but upper limit for font size = 50
+  map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 

--- a/manualDataThirdPhase/win7_magnifier_tophalf_6-0.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_6-0.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
   magnification = 6.0
   magnifierPosition = "TopHalf"
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_tophalf_6-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_tophalf_6-0_sn.ini
@@ -1,31 +1,31 @@
 [context]
-user = "win7_magnifier_tophalf_2-0"
+user = "win7_magnifier_tophalf_6-0_sn"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 6.0
   magnifierPosition = "TopHalf"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
-  Magnification = 200
+  Magnification = 600
   MagnificationMode = 1
   FollowFocus = 1
   FollowCaret = 1
   FollowMouse = 1
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   magnifierEnabled = true
-  magnification = 2.0
+  magnification = 6.0
   magnifierPosition = "TopHalf"
-  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
-  mag-factor = 2.0
+  mag-factor = 6.0
   screen-position = "top-half"
   mouse-tracking = "proportional"
 
@@ -37,12 +37,12 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications
 app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
   ; as multiple of 12 points
-  fontScale = 2.0
+  fontScale = 6.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
   ; No magnification supported in Pilot 2, so using font scale as a fallback
-  ; 48 = 12 * 2 * 2.0 
-  map\\.string\\.fontsize\\.$t = 48
+  ; 144 = 12 * 2 * 6.0 but upper limit for font size = 50
+  map\\.string\\.fontsize\\.$t = 50
   ; @@map.string.iconsize.$t scale to be confirmed by Omnitor
 


### PR DESCRIPTION
Avoid launching both the Windows Magnifier and the magnifier in the SuperNova Access Suite. 
