### PR TITLE
GPII-1112: font size, cursor size, colour inversion, system volume

### DIFF
--- a/manualDataThirdPhase/systemvolume_000.ini
+++ b/manualDataThirdPhase/systemvolume_000.ini
@@ -1,0 +1,31 @@
+; system volume. File name convention: systemvolume_xxx where xxx maps to the common term value as x.xx (see smarthouses).
+[context]
+user = "systemvolume_000"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 0.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 0
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; no screen reader, but has language setting
+  "language": "English"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms  
+  "volume": 0.0
+

--- a/manualDataThirdPhase/systemvolume_006.ini
+++ b/manualDataThirdPhase/systemvolume_006.ini
@@ -1,0 +1,29 @@
+[context]
+user = "systemvolume_006"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.066
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 6.6
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 6.6
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms  
+  "volume": 0.06
+

--- a/manualDataThirdPhase/systemvolume_010.ini
+++ b/manualDataThirdPhase/systemvolume_010.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_010"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.1
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 10.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 1
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 10
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms  
+  "volume": 0.10
+

--- a/manualDataThirdPhase/systemvolume_013.ini
+++ b/manualDataThirdPhase/systemvolume_013.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_013"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.133
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 13.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 2
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 13.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms  
+  "volume": 0.13
+

--- a/manualDataThirdPhase/systemvolume_026.ini
+++ b/manualDataThirdPhase/systemvolume_026.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_026"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.266
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 26.6
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 4
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 26.6
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms  
+  "volume": 0.26
+

--- a/manualDataThirdPhase/systemvolume_033.ini
+++ b/manualDataThirdPhase/systemvolume_033.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_033"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.333
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 33.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 5
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 33.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms 
+  "volume": 0.33
+

--- a/manualDataThirdPhase/systemvolume_040.ini
+++ b/manualDataThirdPhase/systemvolume_040.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_040"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.4
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 40.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 6
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 40.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms 
+  "volume": 0.40
+

--- a/manualDataThirdPhase/systemvolume_047.ini
+++ b/manualDataThirdPhase/systemvolume_047.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_047"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.466
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 46.6
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 7
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 46.6
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms 
+  "volume": 0.47
+

--- a/manualDataThirdPhase/systemvolume_053.ini
+++ b/manualDataThirdPhase/systemvolume_053.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_053"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.533
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 53.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 8
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 53.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms 
+  "volume": 0.53
+

--- a/manualDataThirdPhase/systemvolume_060.ini
+++ b/manualDataThirdPhase/systemvolume_060.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_060"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.6
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 60.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 9
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 60.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms 
+  "volume": 0.60
+

--- a/manualDataThirdPhase/systemvolume_067.ini
+++ b/manualDataThirdPhase/systemvolume_067.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_067"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.667
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 66.7
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 10
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 66.7
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms 
+  "volume": 0.67
+

--- a/manualDataThirdPhase/systemvolume_073.ini
+++ b/manualDataThirdPhase/systemvolume_073.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_073"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.733
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 73.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 11
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 73.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms 
+  "volume": 0.73
+

--- a/manualDataThirdPhase/systemvolume_080.ini
+++ b/manualDataThirdPhase/systemvolume_080.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_080"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 80.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 12
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 80.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms 
+  "volume": 0.80
+

--- a/manualDataThirdPhase/systemvolume_087.ini
+++ b/manualDataThirdPhase/systemvolume_087.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_087"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.866
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 86.7
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 13
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 86.7
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms 
+  "volume": 0.87
+

--- a/manualDataThirdPhase/systemvolume_093.ini
+++ b/manualDataThirdPhase/systemvolume_093.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_093"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 0.933
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 93.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 14
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 93.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms 
+  "volume": 0.93
+

--- a/manualDataThirdPhase/systemvolume_100.ini
+++ b/manualDataThirdPhase/systemvolume_100.ini
@@ -1,0 +1,28 @@
+[context]
+user = "systemvolume_100"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  volume = 1.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.alsa-project"
+  ; volume * 100
+  "masterVolume": 100
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volume * 15; integer
+  "STREAM_SYSTEM": 15
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; volume * 100, but @@ lowest value is 1!?
+  "volume": 100
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; = common terms 
+  "volume": 1.0
+

--- a/manualDataThirdPhase/win7_colourinversion_01.ini
+++ b/manualDataThirdPhase/win7_colourinversion_01.ini
@@ -1,0 +1,33 @@
+[context]
+user = "win7_colourinversion_01"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  invertColours = true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "Magnification": 100
+  "MagnificationMode": 2
+  "Invert": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "mag-factor": 1.0
+  "invert-lightness": true
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "invertColours": true
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+  ; @@ not officially part of the pilots
+  "brightness": 100
+

--- a/manualDataThirdPhase/win7_colourinversion_02.ini
+++ b/manualDataThirdPhase/win7_colourinversion_02.ini
@@ -1,0 +1,38 @@
+[context]
+user = "win7_colourinversion_02"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  invertColours = true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "Magnification": 100
+  "MagnificationMode": 2
+  "Invert": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  ; @@ not officially part of the pilots - removed from this NP set
+  ; "MouseTrails": 5
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "mag-factor": 1.0
+  "invert-lightness": true
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "invertColours": true
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+  ; @@ not officially part of the pilots
+  "brightness": 100
+

--- a/manualDataThirdPhase/win7_colourinversion_03.ini
+++ b/manualDataThirdPhase/win7_colourinversion_03.ini
@@ -1,0 +1,35 @@
+[context]
+user = "win7_colourinversion_03"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  invertColours = true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "Magnification": 110
+  "MagnificationMode": 2
+  "Invert": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "mag-factor": 1.1
+  "invert-lightness": true
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "invertColours": true
+  "magnifierEnabled": true
+  "magnification": 1.1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+  ; @@ not officially part of the pilots
+  "brightness": 100
+

--- a/manualDataThirdPhase/win7_colourinversion_04.ini
+++ b/manualDataThirdPhase/win7_colourinversion_04.ini
@@ -1,0 +1,39 @@
+[context]
+user = "win7_colourinversion_04"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  invertColours = true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "Magnification": 110
+  "MagnificationMode": 2
+  "Invert": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  "MouseTrails": 5
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "mag-factor": 1.1
+  "invert-lightness": true
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "invertColours": true
+  "magnifierEnabled": true
+  "magnification": 1.1
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+  ; @@ not officially part of the pilots
+  "brightness": 100
+

--- a/manualDataThirdPhase/win7_colourinversion_c4chrome_01.ini
+++ b/manualDataThirdPhase/win7_colourinversion_c4chrome_01.ini
@@ -1,0 +1,35 @@
+; colour inversion in Cloud4Chrome only.
+[context]
+user = "win7_colourinversion_c4chrome_01"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  invertColours = true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "Magnification": 100
+  "MagnificationMode": 2
+  "Invert": true
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "mag-factor": 1.0
+  "invert-lightness": true
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "invertColours": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+  ; @@ not officially part of the pilots
+  "brightness": 100
+

--- a/manualDataThirdPhase/win7_colourinversion_c4chrome_02.ini
+++ b/manualDataThirdPhase/win7_colourinversion_c4chrome_02.ini
@@ -1,0 +1,40 @@
+; colour inversion in Cloud4Chrome only.
+[context]
+user = "win7_colourinversion_c4chrome_02"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  invertColours = true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "Magnification": 100
+  "MagnificationMode": 2
+  "Invert": true
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  ; @@ not officially part of the pilots - removed from this NP set
+  ; "MouseTrails": 5
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "mag-factor": 1.0
+  "invert-lightness": true
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "invertColours": true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+  ; @@ not officially part of the pilots
+  "brightness": 100
+

--- a/manualDataThirdPhase/win7_colourinversion_off_03.ini
+++ b/manualDataThirdPhase/win7_colourinversion_off_03.ini
@@ -1,0 +1,31 @@
+; no colour inversion
+[context]
+user = "win7_colourinversion_off_03"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  invertColours = false
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "Magnification": 110
+  "MagnificationMode": 2
+  "Invert": false
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "mag-factor": 1.1
+  "invert-lightness": false
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "invertColours": false
+  "magnifierEnabled": true
+  "magnification": 1.1
+  _disabled=true
+

--- a/manualDataThirdPhase/win7_colourinversion_off_04.ini
+++ b/manualDataThirdPhase/win7_colourinversion_off_04.ini
@@ -1,0 +1,31 @@
+; no colour inversion
+[context]
+user = "win7_colourinversion_off_04"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  invertColours = false
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "Magnification": 110
+  "MagnificationMode": 2
+  "Invert": false
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  ; Colour inversion requires turning on the magnifier
+  "mag-factor": 1.1
+  "invert-lightness": false
+  "screen-position": "full-screen"
+  "mouse-tracking": "proportional"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "invertColours": false
+  "magnifierEnabled": true
+  "magnification": 1.1
+  _disabled=true
+

--- a/manualDataThirdPhase/win7_cursorsize_01.ini
+++ b/manualDataThirdPhase/win7_cursorsize_01.ini
@@ -1,0 +1,31 @@
+; small cursor size & smaller font size on Fedora 20 with Gnome 3.10
+[context]
+user = "win7_cursorsize_01"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  cursorSize = 0.1
+  ; @@ default on common term should be 0? 
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up.cur"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  "text-scaling-factor": 0.9
+  "cursor-size": -1
+

--- a/manualDataThirdPhase/win7_cursorsize_02.ini
+++ b/manualDataThirdPhase/win7_cursorsize_02.ini
@@ -1,0 +1,31 @@
+; normal cursor size & normal font size on Fedora 20 with Gnome 3.10
+[context]
+user = "win7_cursorsize_02"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  cursorSize = 0.2
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up.cur"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  "text-scaling-factor": 1.0
+  ; default cursot size = 24
+  "cursor-size": 24
+

--- a/manualDataThirdPhase/win7_cursorsize_03.ini
+++ b/manualDataThirdPhase/win7_cursorsize_03.ini
@@ -1,0 +1,30 @@
+; normal cursor size & normal font size on Fedora 20 with Gnome 3.10
+[context]
+user = "win7_cursorsize_03"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  cursorSize = 0.3
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up.cur"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  "text-scaling-factor": 1.0
+  "cursor-size": 12
+

--- a/manualDataThirdPhase/win7_cursorsize_04.ini
+++ b/manualDataThirdPhase/win7_cursorsize_04.ini
@@ -1,0 +1,30 @@
+; normal cursor size & normal font size on Fedora 20 with Gnome 3.10
+[context]
+user = "win7_cursorsize_04"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  cursorSize = 0.5
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up.cur"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  "text-scaling-factor": 1.0
+  "cursor-size": 28
+

--- a/manualDataThirdPhase/win7_cursorsize_11.ini
+++ b/manualDataThirdPhase/win7_cursorsize_11.ini
@@ -1,0 +1,31 @@
+; large cursor size & large font size
+[context]
+user = "win7_cursorsize_11"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  cursorSize = 0.65
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail_l.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link_l.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel_l.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy_l.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow_l.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen_l.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move_l.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw_l.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse_l.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns_l.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew_l.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working_l.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up_l.cur"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  "text-scaling-factor": 1.2
+  ; larger cursor = size 29-40
+  "cursor-size": 29
+

--- a/manualDataThirdPhase/win7_cursorsize_12.ini
+++ b/manualDataThirdPhase/win7_cursorsize_12.ini
@@ -1,0 +1,31 @@
+; large cursor size & large font size
+[context]
+user = "win7_cursorsize_12"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  cursorSize = 0.67
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail_l.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link_l.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel_l.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy_l.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow_l.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen_l.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move_l.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw_l.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse_l.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns_l.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew_l.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working_l.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up_l.cur"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  "text-scaling-factor": 1.3
+  ; larger cursor = size 29-40
+  "cursor-size": 32
+

--- a/manualDataThirdPhase/win7_cursorsize_13.ini
+++ b/manualDataThirdPhase/win7_cursorsize_13.ini
@@ -1,0 +1,31 @@
+; large cursor size & large font size
+[context]
+user = "win7_cursorsize_13"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  cursorSize = 0.7
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail_l.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link_l.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel_l.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy_l.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow_l.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen_l.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move_l.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw_l.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse_l.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns_l.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew_l.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working_l.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up_l.cur"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  "text-scaling-factor": 1.4
+  ; larger cursor = size 29-40
+  "cursor-size": 36
+

--- a/manualDataThirdPhase/win7_cursorsize_21.ini
+++ b/manualDataThirdPhase/win7_cursorsize_21.ini
@@ -1,0 +1,31 @@
+; extra large cursor size & extra large font size
+[context]
+user = "win7_cursorsize_21"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  cursorSize = 0.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail_xl.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link_xl.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel_xl.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy_xl.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow_xl.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen_xl.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move_xl.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw_xl.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse_xl.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns_xl.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew_xl.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working_xl.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up_xl.cur"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  "text-scaling-factor": 1.6
+  ; extra large cursor = size > 40
+  "cursor-size": 41
+

--- a/manualDataThirdPhase/win7_cursorsize_22.ini
+++ b/manualDataThirdPhase/win7_cursorsize_22.ini
@@ -1,0 +1,31 @@
+; extra large cursor size & extra large font size
+[context]
+user = "win7_cursorsize_22"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  cursorSize = 0.9
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail_xl.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link_xl.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel_xl.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy_xl.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow_xl.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen_xl.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move_xl.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw_xl.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse_xl.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns_xl.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew_xl.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working_xl.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up_xl.cur"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  "text-scaling-factor": 1.7
+  ; extra large cursor = size > 40
+  "cursor-size": 42
+

--- a/manualDataThirdPhase/win7_cursorsize_23.ini
+++ b/manualDataThirdPhase/win7_cursorsize_23.ini
@@ -1,0 +1,31 @@
+; extra large cursor size & extra large font size
+[context]
+user = "win7_cursorsize_23"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  cursorSize = 1.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail_xl.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link_xl.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel_xl.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy_xl.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow_xl.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen_xl.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move_xl.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw_xl.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse_xl.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns_xl.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew_xl.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working_xl.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up_xl.cur"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  "text-scaling-factor": 1.8
+  ; extra large cursor = size > 40
+  "cursor-size": 43
+

--- a/manualDataThirdPhase/win7_fontsize_12.ini
+++ b/manualDataThirdPhase/win7_fontsize_12.ini
@@ -1,0 +1,63 @@
+; win7_fontsize_xx where xx represents the font size value for the common term
+[context]
+user = "win7_fontsize_12"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  fontSize = 12
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up.cur"
+
+  ; @@WARNING: font size not supported on Windows.
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  ; value from common term / 12
+  "text-scaling-factor": 1.0
+  "cursor-size": 24
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; value from common term * 1.33 
+  "fontSize": 16
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; based on common term: <= 12: "small"; <= 24: "medium"; <= 32: "large"; <= 42: "veryLarge"; > 42: "huge"
+  "fontSize": "small"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; value from common term / 12; range = 0.5 - 2.0
+  "fontScale": 1.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; value from common term * 2
+  "map\\.string\\.fontsize\\.$t": 24
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  ; common term < 12 = "medium"; < 18: "large"; >= 18: "x-large"
+  "fontSize": "medium"
+
+[preferences]
+app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
+  ; everything <= 14 is "normal"; everything > 14 is "large"
+  "fontSize": "normal"
+

--- a/manualDataThirdPhase/win7_fontsize_14.ini
+++ b/manualDataThirdPhase/win7_fontsize_14.ini
@@ -1,0 +1,62 @@
+[context]
+user = "win7_fontsize_14"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  fontSize = 14
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up.cur"
+
+  ; @@WARNING: font size not supported on Windows.
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  ; value from common term / 12
+  "text-scaling-factor": 1.16
+  "cursor-size": 26
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; value from common term * 1.33 
+  "fontSize": 19
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; based on common term: <= 12: "small"; <= 24: "medium"; <= 32: "large"; <= 42: "veryLarge"; > 42: "huge"
+  "fontSize": "medium"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; value from common term / 12; range = 0.5 - 2.0
+  "fontScale": 1.16
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; value from common term * 2
+  "map\\.string\\.fontsize\\.$t": 28
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  ; common term < 12 = "medium"; < 18: "large"; >= 18: "x-large"
+  "fontSize": "large"
+
+[preferences]
+app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
+  ; everything <= 14 is "normal"; everything > 14 is "large"
+  "fontSize": "normal"
+

--- a/manualDataThirdPhase/win7_fontsize_15.ini
+++ b/manualDataThirdPhase/win7_fontsize_15.ini
@@ -1,0 +1,62 @@
+[context]
+user = "win7_fontsize_15"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  fontSize = 15
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail_l.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link_l.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel_l.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy_l.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow_l.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen_l.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move_l.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw_l.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse_l.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns_l.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew_l.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working_l.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up_l.cur"
+
+  ; @@WARNING: font size not supported on Windows.
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  ; value from common term / 12
+  "text-scaling-factor": 1.25
+  "cursor-size": 32
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; value from common term * 1.33 
+  "fontSize": 20
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; based on common term: <= 12: "small"; <= 24: "medium"; <= 32: "large"; <= 42: "veryLarge"; > 42: "huge"
+  "fontSize": "medium"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; value from common term / 12; range = 0.5 - 2.0
+  "fontScale": 1.25
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; value from common term * 2
+  "map\\.string\\.fontsize\\.$t": 30
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  ; common term < 12 = "medium"; < 18: "large"; >= 18: "x-large"
+  "fontSize": "large"
+
+[preferences]
+app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
+  ; everything <= 14 is "normal"; everything > 14 is "large"
+  "fontSize": "large"
+

--- a/manualDataThirdPhase/win7_fontsize_16.ini
+++ b/manualDataThirdPhase/win7_fontsize_16.ini
@@ -1,0 +1,62 @@
+[context]
+user = "win7_fontsize_16"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  fontSize = 16
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail_l.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link_l.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel_l.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy_l.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow_l.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen_l.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move_l.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw_l.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse_l.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns_l.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew_l.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working_l.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up_l.cur"
+
+  ; @@WARNING: font size not supported on Windows.
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  ; value from common term / 12
+  "text-scaling-factor": 1.33
+  "cursor-size": 34
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; value from common term * 1.33 
+  "fontSize": 21
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; based on common term: <= 12: "small"; <= 24: "medium"; <= 32: "large"; <= 42: "veryLarge"; > 42: "huge"
+  "fontSize": "medium"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; value from common term / 12; range = 0.5 - 2.0
+  "fontScale": 1.33
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; value from common term * 2
+  "map\\.string\\.fontsize\\.$t": 32
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  ; common term < 12 = "medium"; < 18: "large"; >= 18: "x-large"
+  "fontSize": "large"
+
+[preferences]
+app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
+  ; everything <= 14 is "normal"; everything > 14 is "large"
+  "fontSize": "large"
+

--- a/manualDataThirdPhase/win7_fontsize_18.ini
+++ b/manualDataThirdPhase/win7_fontsize_18.ini
@@ -1,0 +1,62 @@
+[context]
+user = "win7_fontsize_18"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  fontSize = 18
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail_l.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link_l.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel_l.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy_l.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow_l.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen_l.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move_l.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw_l.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse_l.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns_l.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew_l.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working_l.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up_l.cur"
+
+  ; @@WARNING: font size not supported on Windows.
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  ; value from common term / 12
+  "text-scaling-factor": 1.5
+  "cursor-size": 38
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; value from common term * 1.33 
+  "fontSize": 24
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; based on common term: <= 12: "small"; <= 24: "medium"; <= 32: "large"; <= 42: "veryLarge"; > 42: "huge"
+  "fontSize": "medium"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; value from common term / 12; range = 0.5 - 2.0
+  "fontScale": 1.33
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; value from common term * 2
+  "map\\.string\\.fontsize\\.$t": 32
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  ; common term < 12 = "medium"; < 18: "large"; >= 18: "x-large"
+  "fontSize": "large"
+
+[preferences]
+app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
+  ; everything <= 14 is "normal"; everything > 14 is "large"
+  "fontSize": "large"
+

--- a/manualDataThirdPhase/win7_fontsize_20.ini
+++ b/manualDataThirdPhase/win7_fontsize_20.ini
@@ -1,0 +1,62 @@
+[context]
+user = "win7_fontsize_20"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  fontSize = 20
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail_l.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link_l.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel_l.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy_l.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow_l.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen_l.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move_l.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw_l.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse_l.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns_l.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew_l.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working_l.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up_l.cur"
+
+  ; @@WARNING: font size not supported on Windows.
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  ; value from common term / 12
+  "text-scaling-factor": 1.66
+  "cursor-size": 40
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; value from common term * 1.33 
+  "fontSize": 27
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; based on common term: <= 12: "small"; <= 24: "medium"; <= 32: "large"; <= 42: "veryLarge"; > 42: "huge"
+  "fontSize": "medium"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; value from common term / 12; range = 0.5 - 2.0
+  "fontScale": 1.66
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; value from common term * 2
+  "map\\.string\\.fontsize\\.$t": 40
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  ; common term < 12 = "medium"; < 18: "large"; >= 18: "x-large"
+  "fontSize": "x-large"
+
+[preferences]
+app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
+  ; everything <= 14 is "normal"; everything > 14 is "large"
+  "fontSize": "large"
+

--- a/manualDataThirdPhase/win7_fontsize_24.ini
+++ b/manualDataThirdPhase/win7_fontsize_24.ini
@@ -1,0 +1,62 @@
+[context]
+user = "win7_fontsize_24"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  fontSize = 24
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.cursors"
+  "No": "%SystemRoot%\\cursors\\aero_unavail_xl.cur"
+  "Hand": "%SystemRoot%\\cursors\\aero_link_xl.cur"
+  "Help": "%SystemRoot%\\cursors\\aero_helpsel_xl.cur"
+  "Wait": "%SystemRoot%\\cursors\\aero_busy_xl.ani"
+  "Arrow": "%SystemRoot%\\cursors\\aero_arrow_xl.cur"
+  "NWPen": "%SystemRoot%\\cursors\\aero_pen_xl.cur"
+  "SizeAll": "%SystemRoot%\\cursors\\aero_move_xl.cur"
+  "SizeNESW": "%SystemRoot%\\cursors\\aero_nesw_xl.cur"
+  "SizeNWSE": "%SystemRoot%\\cursors\\aero_nwse_xl.cur"
+  "SizeNS": "%SystemRoot%\\cursors\\aero_ns_xl.cur"
+  "SizeWE": "%SystemRoot%\\cursors\\aero_ew_xl.cur"
+  "AppStarting": "%SystemRoot%\\cursors\\aero_working_xl.ani"
+  "UpArrow": "%SystemRoot%\\cursors\\aero_up_xl.cur"
+
+  ; @@WARNING: font size not supported on Windows.
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
+  ; value from common term / 12
+  "text-scaling-factor": 2.0
+  "cursor-size": 48
+
+[preferences]
+app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  ; value from common term * 1.33 
+  "fontSize": 32
+
+[preferences]
+app = "http://registry.gpii.net/applications/info.cloud4all.JME"
+  ; based on common term: <= 12: "small"; <= 24: "medium"; <= 32: "large"; <= 42: "veryLarge"; > 42: "huge"
+  "fontSize": "large"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; value from common term / 12; range = 0.5 - 2.0
+  "fontScale": 2.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/se.omnitor.ecmobile"
+  ; value from common term * 2
+  "map\\.string\\.fontsize\\.$t": 48
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  ; common term < 12 = "medium"; < 18: "large"; >= 18: "x-large"
+  "fontSize": "x-large"
+
+[preferences]
+app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
+  ; everything <= 14 is "normal"; everything > 14 is "large"
+  "fontSize": "large"
+


### PR DESCRIPTION
GPII-1112: STMM training data for **font size** (Linux GNOME, smart house, Android, ecmobile, Cloud4Chrome, Sociable), **cursor size** (MS Windows, Linux GNOME), **colour inversion** (MS Windows, Linux GNOME, Cloud4Chrome; brightness on Android), **system volume** (Linux GNOME ALSA, Android, JME, smart house multimedia system). 
