### PR TITLE
GPII-1112: high speech rate Win, Lin, SuperNova, M11y, Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.ini~2~
 *.ini#
 *.marks
+*.ini~3~

--- a/manualDataThirdPhase/screenreader_160.ini
+++ b/manualDataThirdPhase/screenreader_160.ini
@@ -1,0 +1,140 @@
+; screen reader settings on Windows, Linux, Android, ...
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_160"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 160
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 25.81
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "fr"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 300
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 35
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 40
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  "voices.default.rate": 50
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "fr"
+  "voices.default.family.name": "french"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 0
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 3.5
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 4.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
+  "always-show-universal-access-status": true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
+  ; auditoryOutLanguage
+  "locale": "fr"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
+  ; auditoryOutLanguage
+  "locale": "fr"
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "screenReaderTTSEnabled": true
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "screenReaderBrailleOutput": false
+  "screenReaderTTSEnabled": true
+  "speechRate": 99
+  "punctuationVerbosity": "all"
+  "announceCapitals": true
+  ; keyEcho and wordEcho
+  "keyEcho": true
+  "wordEcho": true
+  _disabled=true
+
+
+; Mobile Accessibility for Android (CodeFactory)
+[preferences]
+app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
+  "access_commonprefs_speechrate": 4.03
+  ; punctuationVerbosity
+  "access_commonprefs_punctuation": "all"
+  ; announceCapitals
+  "access_commonprefs_capitalization": true
+  ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
+  "access_commonprefs_editingkeyboardecho": 3
+  ; pitch * 10 (MAA default : 5)
+  "access_commonprefs_speechpitch": 4
+
+
+; Android with TalkBack (FVE)
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.freespeech"
+  ; just start freespeech
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.talkback"
+  ; just start talkback
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
+  "locale": "fr"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volumeTTS * 15
+  "STREAM_MUSIC": 5.25
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.secure"
+  ; @@relationship to WPM not well established!!
+  "tts_default_rate": 160
+  ; pitch * 500 (Android default: 100)
+  "tts_default_pitch": 200

--- a/manualDataThirdPhase/screenreader_160_m11y.ini
+++ b/manualDataThirdPhase/screenreader_160_m11y.ini
@@ -1,7 +1,7 @@
 ; screen reader settings on Windows, Linux, Android, ...
 ; screen reader with TTS; Braille is disabled
 [context]
-user = "screenreader_160"
+user = "screenreader_160_m11y"
 os = "windows"
 
 [preferences]
@@ -107,36 +107,5 @@ app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
   "access_commonprefs_editingkeyboardecho": 3
   ; pitch * 10 (MAA default : 5)
   "access_commonprefs_speechpitch": 4
-  _disabled=true
 
-
-; Android with TalkBack (FVE)
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.freespeech"
-  ; just start freespeech
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.talkback"
-  ; just start talkback
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
-  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
-  "locale": "fr"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.audioManager"
-  ; volumeTTS * 15
-  "STREAM_MUSIC": 5.25
-
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.system"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.secure"
-  ; @@relationship to WPM not well established!!
-  "tts_default_rate": 160
-  ; pitch * 500 (Android default: 100)
-  "tts_default_pitch": 200
 

--- a/manualDataThirdPhase/screenreader_173.ini
+++ b/manualDataThirdPhase/screenreader_173.ini
@@ -106,6 +106,7 @@ app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
   "access_commonprefs_editingkeyboardecho": 0
   ; pitch * 10 (MAA default : 5)
   "access_commonprefs_speechpitch": 5
+  _disabled=true
 
 
 ; Android with TalkBack (FVE)

--- a/manualDataThirdPhase/screenreader_173.ini
+++ b/manualDataThirdPhase/screenreader_173.ini
@@ -1,0 +1,139 @@
+; screen reader settings on Windows, Linux, Android, ...
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_173"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 173
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 30
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "it"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 0
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": False
+  "keyboard.speakTypedWords": False
+  ; volumeTTS * 100
+  "speech.espeak.volume": 20
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  "voices.default.rate": 54.33
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "it"
+  "voices.default.family.name": "italian"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 3
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": false
+  "enableEchoByWord": false
+  ; volumeTTS * 10
+  "voices.default.gain": 2
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
+  "always-show-universal-access-status": true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
+  ; auditoryOutLanguage
+ "locale": "it"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
+  ; auditoryOutLanguage
+  "locale": "it"
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "screenReaderTTSEnabled": true
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "screenReaderBrailleOutput": false
+  "screenReaderTTSEnabled": true
+  "speechRate": 107.5
+  "punctuationVerbosity": "none"
+  "announceCapitals": true
+  ; keyEcho and wordEcho
+  "keyEcho": false
+  "wordEcho": false
+
+
+; Mobile Accessibility for Android (CodeFactory)
+[preferences]
+app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
+  "access_commonprefs_speechrate": 4.33
+  ; punctuationVerbosity
+  "access_commonprefs_punctuation": "none"
+  ; announceCapitals
+  "access_commonprefs_capitalization": true
+  ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
+  "access_commonprefs_editingkeyboardecho": 0
+  ; pitch * 10 (MAA default : 5)
+  "access_commonprefs_speechpitch": 5
+
+
+; Android with TalkBack (FVE)
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.freespeech"
+  ; just start freespeech
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.talkback"
+  ; just start talkback
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
+  "locale": "it"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volumeTTS * 15
+  "STREAM_MUSIC": 3
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.secure"
+  ; @@relationship to WPM not well established!!
+  "tts_default_rate": 173
+  ; pitch * 500 (Android default: 100)
+  "tts_default_pitch": 250

--- a/manualDataThirdPhase/screenreader_173_m11y.ini
+++ b/manualDataThirdPhase/screenreader_173_m11y.ini
@@ -1,12 +1,12 @@
 ; screen reader settings on Windows, Linux, Android, ...
 ; screen reader with TTS; Braille is disabled
 [context]
-user = "screenreader_160"
+user = "screenreader_173_m11y"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
-  speechRate = 160
+  speechRate = 173
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
@@ -15,48 +15,48 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; screenReaderTTSEnabled
   "speech.synth": "espeak"
   "speech.outputDevice": "Microsoft Sound Mapper"
-  "speech.espeak.rate": 25.81
+  "speech.espeak.rate": 30
   ; auditoryOutLanguage
-  "speech.espeak.voice": "fr"
+  "speech.espeak.voice": "it"
   ; trackingTTS
   "reviewCursor.followFocus": True
   "reviewCursor.followCaret": True
   "reviewCursor.followMouse": True
   ; punctuationVerbosity (default: some = 100)
-  "speech.symbolLevel": 300
+  "speech.symbolLevel": 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
   "virtualBuffers.autoSayAllOnPageLoad": True
   ; announceCapitals
   "speech.espeak.sayCapForCapitals": True
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters": True
-  "keyboard.speakTypedWords": True
+  "keyboard.speakTypedCharacters": False
+  "keyboard.speakTypedWords": False
   ; volumeTTS * 100
-  "speech.espeak.volume": 35
+  "speech.espeak.volume": 20
   ; pitch * 100 (NVDA default = 40)
-  "speech.espeak.pitch": 40
+  "speech.espeak.pitch": 50
 
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.orca"
   "enableBraille": false
   "enableSpeech": true
-  "voices.default.rate": 50
+  "voices.default.rate": 54.33
   ; auditoryOutLanguage
-  "voices.default.family.locale": "fr"
-  "voices.default.family.name": "french"
+  "voices.default.family.locale": "it"
+  "voices.default.family.name": "italian"
   ; punctuationVerbosity (some = 2)
-  "verbalizePunctuationStyle": 0
+  "verbalizePunctuationStyle": 3
   ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
   "sayAllStyle": 1
   ; announceCapitals: not supported
   ; keyEcho and wordEcho
-  "enableEchoByCharacter": true
-  "enableEchoByWord": true
+  "enableEchoByCharacter": false
+  "enableEchoByWord": false
   ; volumeTTS * 10
-  "voices.default.gain": 3.5
+  "voices.default.gain": 2
   ; pitch * 10 (Orca default: 5.0)
-  "voices.default.average-pitch": 4.0
+  "voices.default.average-pitch": 5.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
@@ -66,13 +66,13 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
   ; auditoryOutLanguage
-  "locale": "fr"
+ "locale": "it"
   _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "it"
   _disabled=true
 
 
@@ -86,57 +86,25 @@ app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "screenReaderBrailleOutput": false
   "screenReaderTTSEnabled": true
-  "speechRate": 99
-  "punctuationVerbosity": "all"
+  "speechRate": 107.5
+  "punctuationVerbosity": "none"
   "announceCapitals": true
   ; keyEcho and wordEcho
-  "keyEcho": true
-  "wordEcho": true
-  _disabled=true
+  "keyEcho": false
+  "wordEcho": false
 
 
 ; Mobile Accessibility for Android (CodeFactory)
 [preferences]
 app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
-  "access_commonprefs_speechrate": 4.03
+  "access_commonprefs_speechrate": 4.33
   ; punctuationVerbosity
-  "access_commonprefs_punctuation": "all"
+  "access_commonprefs_punctuation": "none"
   ; announceCapitals
   "access_commonprefs_capitalization": true
   ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
-  "access_commonprefs_editingkeyboardecho": 3
+  "access_commonprefs_editingkeyboardecho": 0
   ; pitch * 10 (MAA default : 5)
-  "access_commonprefs_speechpitch": 4
-  _disabled=true
+  "access_commonprefs_speechpitch": 5
 
-
-; Android with TalkBack (FVE)
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.freespeech"
-  ; just start freespeech
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.talkback"
-  ; just start talkback
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
-  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
-  "locale": "fr"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.audioManager"
-  ; volumeTTS * 15
-  "STREAM_MUSIC": 5.25
-
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.system"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.secure"
-  ; @@relationship to WPM not well established!!
-  "tts_default_rate": 160
-  ; pitch * 500 (Android default: 100)
-  "tts_default_pitch": 200
 

--- a/manualDataThirdPhase/screenreader_184.ini
+++ b/manualDataThirdPhase/screenreader_184.ini
@@ -106,6 +106,7 @@ app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
   "access_commonprefs_editingkeyboardecho": 1
   ; pitch * 10 (MAA default : 5)
   "access_commonprefs_speechpitch": 6
+  _disabled=true
 
 
 ; Android with TalkBack (FVE)
@@ -137,3 +138,4 @@ app = "http://registry.gpii.net/applications/com.android.settings.secure"
   "tts_default_rate": 184
   ; pitch * 500 (Android default: 100)
   "tts_default_pitch": 300
+

--- a/manualDataThirdPhase/screenreader_184.ini
+++ b/manualDataThirdPhase/screenreader_184.ini
@@ -1,0 +1,139 @@
+; screen reader settings on Windows, Linux, Android, ...
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_184"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 184
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 33.55
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "nl"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": False
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": False
+  ; volumeTTS * 100
+  "speech.espeak.volume": 5
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 60
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  "voices.default.rate": 58
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "nl"
+  "voices.default.family.name": "dutch"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 2
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": false
+  ; volumeTTS * 10
+  "voices.default.gain": 0.5
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 6.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
+  "always-show-universal-access-status": true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
+  ; auditoryOutLanguage
+  "locale": "nl"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
+  ; auditoryOutLanguage
+  "locale": "nl"
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "screenReaderTTSEnabled": true
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "screenReaderBrailleOutput": false
+  "screenReaderTTSEnabled": true
+  "speechRate": 114.5
+  "punctuationVerbosity": "some"
+  "announceCapitals": false
+  ; keyEcho and wordEcho
+  "keyEcho": true
+  "wordEcho": false
+
+
+; Mobile Accessibility for Android (CodeFactory)
+[preferences]
+app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
+  "access_commonprefs_speechrate": 4.6
+  ; punctuationVerbosity
+  "access_commonprefs_punctuation": "some"
+  ; announceCapitals
+  "access_commonprefs_capitalization": false
+  ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
+  "access_commonprefs_editingkeyboardecho": 1
+  ; pitch * 10 (MAA default : 5)
+  "access_commonprefs_speechpitch": 6
+
+
+; Android with TalkBack (FVE)
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.freespeech"
+  ; just start freespeech
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.talkback"
+  ; just start talkback
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
+  "locale": "no"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volumeTTS * 15
+  "STREAM_MUSIC": 0.75
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.secure"
+  ; @@relationship to WPM not well established!!
+  "tts_default_rate": 184
+  ; pitch * 500 (Android default: 100)
+  "tts_default_pitch": 300

--- a/manualDataThirdPhase/screenreader_184_m11y.ini
+++ b/manualDataThirdPhase/screenreader_184_m11y.ini
@@ -1,12 +1,12 @@
 ; screen reader settings on Windows, Linux, Android, ...
 ; screen reader with TTS; Braille is disabled
 [context]
-user = "screenreader_160"
+user = "screenreader_184_m11y"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
-  speechRate = 160
+  speechRate = 184
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
@@ -15,48 +15,48 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; screenReaderTTSEnabled
   "speech.synth": "espeak"
   "speech.outputDevice": "Microsoft Sound Mapper"
-  "speech.espeak.rate": 25.81
+  "speech.espeak.rate": 33.55
   ; auditoryOutLanguage
-  "speech.espeak.voice": "fr"
+  "speech.espeak.voice": "nl"
   ; trackingTTS
   "reviewCursor.followFocus": True
   "reviewCursor.followCaret": True
   "reviewCursor.followMouse": True
   ; punctuationVerbosity (default: some = 100)
-  "speech.symbolLevel": 300
+  "speech.symbolLevel": 100
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
   "virtualBuffers.autoSayAllOnPageLoad": True
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals": True
+  "speech.espeak.sayCapForCapitals": False
   ; keyEcho and wordEcho
   "keyboard.speakTypedCharacters": True
-  "keyboard.speakTypedWords": True
+  "keyboard.speakTypedWords": False
   ; volumeTTS * 100
-  "speech.espeak.volume": 35
+  "speech.espeak.volume": 5
   ; pitch * 100 (NVDA default = 40)
-  "speech.espeak.pitch": 40
+  "speech.espeak.pitch": 60
 
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.orca"
   "enableBraille": false
   "enableSpeech": true
-  "voices.default.rate": 50
+  "voices.default.rate": 58
   ; auditoryOutLanguage
-  "voices.default.family.locale": "fr"
-  "voices.default.family.name": "french"
+  "voices.default.family.locale": "nl"
+  "voices.default.family.name": "dutch"
   ; punctuationVerbosity (some = 2)
-  "verbalizePunctuationStyle": 0
+  "verbalizePunctuationStyle": 2
   ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
   "sayAllStyle": 1
   ; announceCapitals: not supported
   ; keyEcho and wordEcho
   "enableEchoByCharacter": true
-  "enableEchoByWord": true
+  "enableEchoByWord": false
   ; volumeTTS * 10
-  "voices.default.gain": 3.5
+  "voices.default.gain": 0.5
   ; pitch * 10 (Orca default: 5.0)
-  "voices.default.average-pitch": 4.0
+  "voices.default.average-pitch": 6.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
@@ -66,13 +66,13 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "nl"
   _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "nl"
   _disabled=true
 
 
@@ -86,57 +86,25 @@ app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "screenReaderBrailleOutput": false
   "screenReaderTTSEnabled": true
-  "speechRate": 99
-  "punctuationVerbosity": "all"
-  "announceCapitals": true
+  "speechRate": 114.5
+  "punctuationVerbosity": "some"
+  "announceCapitals": false
   ; keyEcho and wordEcho
   "keyEcho": true
-  "wordEcho": true
-  _disabled=true
+  "wordEcho": false
 
 
 ; Mobile Accessibility for Android (CodeFactory)
 [preferences]
 app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
-  "access_commonprefs_speechrate": 4.03
+  "access_commonprefs_speechrate": 4.6
   ; punctuationVerbosity
-  "access_commonprefs_punctuation": "all"
+  "access_commonprefs_punctuation": "some"
   ; announceCapitals
-  "access_commonprefs_capitalization": true
+  "access_commonprefs_capitalization": false
   ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
-  "access_commonprefs_editingkeyboardecho": 3
+  "access_commonprefs_editingkeyboardecho": 1
   ; pitch * 10 (MAA default : 5)
-  "access_commonprefs_speechpitch": 4
-  _disabled=true
+  "access_commonprefs_speechpitch": 6
 
-
-; Android with TalkBack (FVE)
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.freespeech"
-  ; just start freespeech
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.talkback"
-  ; just start talkback
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
-  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
-  "locale": "fr"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.audioManager"
-  ; volumeTTS * 15
-  "STREAM_MUSIC": 5.25
-
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.system"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.secure"
-  ; @@relationship to WPM not well established!!
-  "tts_default_rate": 160
-  ; pitch * 500 (Android default: 100)
-  "tts_default_pitch": 200
 

--- a/manualDataThirdPhase/screenreader_200.ini
+++ b/manualDataThirdPhase/screenreader_200.ini
@@ -106,6 +106,7 @@ app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
   "access_commonprefs_editingkeyboardecho": 2
   ; pitch * 10 (MAA default : 5)
   "access_commonprefs_speechpitch": 7
+  _disabled=true
 
 
 ; Android with TalkBack (FVE)
@@ -137,3 +138,4 @@ app = "http://registry.gpii.net/applications/com.android.settings.secure"
   "tts_default_rate": 200
   ; pitch * 500 (Android default: 100)
   "tts_default_pitch": 350
+

--- a/manualDataThirdPhase/screenreader_200.ini
+++ b/manualDataThirdPhase/screenreader_200.ini
@@ -1,0 +1,139 @@
+; screen reader settings on Windows, Linux, Android, ...
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_200"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 200
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 38.71
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "zh"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": False
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": False
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 90
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 70
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  "voices.default.rate": 63.33
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "zh"
+  "voices.default.family.name": "Mandarin"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": false
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 9
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 7.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
+  "always-show-universal-access-status": true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
+  ; auditoryOutLanguage
+  "locale": "zh"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
+  ; auditoryOutLanguage
+  "locale": "zh"
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "screenReaderTTSEnabled": true
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "screenReaderBrailleOutput": false
+  "screenReaderTTSEnabled": true
+  "speechRate": 125
+  "punctuationVerbosity": "most"
+  "announceCapitals": false
+  ; keyEcho and wordEcho
+  "keyEcho": false
+  "wordEcho": true
+
+
+; Mobile Accessibility for Android (CodeFactory)
+[preferences]
+app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
+  "access_commonprefs_speechrate": 5
+  ; punctuationVerbosity
+  "access_commonprefs_punctuation": "most"
+  ; announceCapitals
+  "access_commonprefs_capitalization": false
+  ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
+  "access_commonprefs_editingkeyboardecho": 2
+  ; pitch * 10 (MAA default : 5)
+  "access_commonprefs_speechpitch": 7
+
+
+; Android with TalkBack (FVE)
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.freespeech"
+  ; just start freespeech
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.talkback"
+  ; just start talkback
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
+  "locale": "zh_CN"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volumeTTS * 15
+  "STREAM_MUSIC": 13.5
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.secure"
+  ; @@relationship to WPM not well established!!
+  "tts_default_rate": 200
+  ; pitch * 500 (Android default: 100)
+  "tts_default_pitch": 350

--- a/manualDataThirdPhase/screenreader_200_m11y.ini
+++ b/manualDataThirdPhase/screenreader_200_m11y.ini
@@ -1,12 +1,12 @@
 ; screen reader settings on Windows, Linux, Android, ...
 ; screen reader with TTS; Braille is disabled
 [context]
-user = "screenreader_160"
+user = "screenreader_200_m11y"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
-  speechRate = 160
+  speechRate = 200
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
@@ -15,48 +15,48 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; screenReaderTTSEnabled
   "speech.synth": "espeak"
   "speech.outputDevice": "Microsoft Sound Mapper"
-  "speech.espeak.rate": 25.81
+  "speech.espeak.rate": 38.71
   ; auditoryOutLanguage
-  "speech.espeak.voice": "fr"
+  "speech.espeak.voice": "zh"
   ; trackingTTS
   "reviewCursor.followFocus": True
   "reviewCursor.followCaret": True
   "reviewCursor.followMouse": True
   ; punctuationVerbosity (default: some = 100)
-  "speech.symbolLevel": 300
+  "speech.symbolLevel": 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
   "virtualBuffers.autoSayAllOnPageLoad": True
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals": True
+  "speech.espeak.sayCapForCapitals": False
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedCharacters": False
   "keyboard.speakTypedWords": True
   ; volumeTTS * 100
-  "speech.espeak.volume": 35
+  "speech.espeak.volume": 90
   ; pitch * 100 (NVDA default = 40)
-  "speech.espeak.pitch": 40
+  "speech.espeak.pitch": 70
 
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.orca"
   "enableBraille": false
   "enableSpeech": true
-  "voices.default.rate": 50
+  "voices.default.rate": 63.33
   ; auditoryOutLanguage
-  "voices.default.family.locale": "fr"
-  "voices.default.family.name": "french"
+  "voices.default.family.locale": "zh"
+  "voices.default.family.name": "Mandarin"
   ; punctuationVerbosity (some = 2)
-  "verbalizePunctuationStyle": 0
+  "verbalizePunctuationStyle": 1
   ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
   "sayAllStyle": 1
   ; announceCapitals: not supported
   ; keyEcho and wordEcho
-  "enableEchoByCharacter": true
+  "enableEchoByCharacter": false
   "enableEchoByWord": true
   ; volumeTTS * 10
-  "voices.default.gain": 3.5
+  "voices.default.gain": 9
   ; pitch * 10 (Orca default: 5.0)
-  "voices.default.average-pitch": 4.0
+  "voices.default.average-pitch": 7.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
@@ -66,13 +66,13 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "zh"
   _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "zh"
   _disabled=true
 
 
@@ -86,57 +86,25 @@ app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "screenReaderBrailleOutput": false
   "screenReaderTTSEnabled": true
-  "speechRate": 99
-  "punctuationVerbosity": "all"
-  "announceCapitals": true
+  "speechRate": 125
+  "punctuationVerbosity": "most"
+  "announceCapitals": false
   ; keyEcho and wordEcho
-  "keyEcho": true
+  "keyEcho": false
   "wordEcho": true
-  _disabled=true
 
 
 ; Mobile Accessibility for Android (CodeFactory)
 [preferences]
 app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
-  "access_commonprefs_speechrate": 4.03
+  "access_commonprefs_speechrate": 5
   ; punctuationVerbosity
-  "access_commonprefs_punctuation": "all"
+  "access_commonprefs_punctuation": "most"
   ; announceCapitals
-  "access_commonprefs_capitalization": true
+  "access_commonprefs_capitalization": false
   ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
-  "access_commonprefs_editingkeyboardecho": 3
+  "access_commonprefs_editingkeyboardecho": 2
   ; pitch * 10 (MAA default : 5)
-  "access_commonprefs_speechpitch": 4
-  _disabled=true
+  "access_commonprefs_speechpitch": 7
 
-
-; Android with TalkBack (FVE)
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.freespeech"
-  ; just start freespeech
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.talkback"
-  ; just start talkback
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
-  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
-  "locale": "fr"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.audioManager"
-  ; volumeTTS * 15
-  "STREAM_MUSIC": 5.25
-
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.system"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.secure"
-  ; @@relationship to WPM not well established!!
-  "tts_default_rate": 160
-  ; pitch * 500 (Android default: 100)
-  "tts_default_pitch": 200
 

--- a/manualDataThirdPhase/screenreader_220.ini
+++ b/manualDataThirdPhase/screenreader_220.ini
@@ -102,6 +102,7 @@ app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
   "access_commonprefs_editingkeyboardecho": 3
   ; pitch * 10 (MAA default : 5)
   "access_commonprefs_speechpitch": 8
+  _disabled=true
 
 
 ; Android with TalkBack (FVE)
@@ -133,3 +134,4 @@ app = "http://registry.gpii.net/applications/com.android.settings.secure"
   "tts_default_rate": 220
   ; pitch * 500 (Android default: 100)
   "tts_default_pitch": 400
+

--- a/manualDataThirdPhase/screenreader_220.ini
+++ b/manualDataThirdPhase/screenreader_220.ini
@@ -1,0 +1,135 @@
+; screen reader settings on Windows, Linux, Android, ...
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_220"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 45.16
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 300
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": False
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 75
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  "voices.default.rate": 70
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "default"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 0
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7.5
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 8.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
+  "always-show-universal-access-status": true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
+  ; auditoryOutLanguage
+  "locale": "en"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
+  ; auditoryOutLanguage
+  "locale": "en"
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "screenReaderTTSEnabled": true
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "screenReaderBrailleOutput": false
+  "screenReaderTTSEnabled": true
+  "speechRate": 137.6
+  "punctuationVerbosity": "all"
+  "announceCapitals": false
+  ; keyEcho and wordEcho
+  "keyEcho": true
+  "wordEcho": true
+
+
+; Mobile Accessibility for Android (CodeFactory)
+[preferences]
+app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
+  "access_commonprefs_speechrate": 5.5
+  ; punctuationVerbosity
+  "access_commonprefs_punctuation": "all"
+  ; announceCapitals
+  "access_commonprefs_capitalization": false
+  ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
+  "access_commonprefs_editingkeyboardecho": 3
+  ; pitch * 10 (MAA default : 5)
+  "access_commonprefs_speechpitch": 8
+
+
+; Android with TalkBack (FVE)
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.freespeech"
+  ; just start freespeech
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.talkback"
+  ; just start talkback
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
+  "locale": "en"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volumeTTS * 15
+  "STREAM_MUSIC": 11.25
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.secure"
+  ; @@relationship to WPM not well established!!
+  "tts_default_rate": 220
+  ; pitch * 500 (Android default: 100)
+  "tts_default_pitch": 400

--- a/manualDataThirdPhase/screenreader_220_m11y.ini
+++ b/manualDataThirdPhase/screenreader_220_m11y.ini
@@ -1,12 +1,8 @@
 ; screen reader settings on Windows, Linux, Android, ...
 ; screen reader with TTS; Braille is disabled
 [context]
-user = "screenreader_160"
+user = "screenreader_220_m11y"
 os = "windows"
-
-[preferences]
-app = "http://registry.gpii.net/common"
-  speechRate = 160
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
@@ -15,9 +11,9 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; screenReaderTTSEnabled
   "speech.synth": "espeak"
   "speech.outputDevice": "Microsoft Sound Mapper"
-  "speech.espeak.rate": 25.81
+  "speech.espeak.rate": 45.16
   ; auditoryOutLanguage
-  "speech.espeak.voice": "fr"
+  "speech.espeak.voice": "en\\en"
   ; trackingTTS
   "reviewCursor.followFocus": True
   "reviewCursor.followCaret": True
@@ -27,24 +23,24 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
   "virtualBuffers.autoSayAllOnPageLoad": True
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals": True
+  "speech.espeak.sayCapForCapitals": False
   ; keyEcho and wordEcho
   "keyboard.speakTypedCharacters": True
   "keyboard.speakTypedWords": True
   ; volumeTTS * 100
-  "speech.espeak.volume": 35
+  "speech.espeak.volume": 75
   ; pitch * 100 (NVDA default = 40)
-  "speech.espeak.pitch": 40
+  "speech.espeak.pitch": 80
 
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.orca"
   "enableBraille": false
   "enableSpeech": true
-  "voices.default.rate": 50
+  "voices.default.rate": 70
   ; auditoryOutLanguage
-  "voices.default.family.locale": "fr"
-  "voices.default.family.name": "french"
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "default"
   ; punctuationVerbosity (some = 2)
   "verbalizePunctuationStyle": 0
   ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
@@ -54,9 +50,9 @@ app = "http://registry.gpii.net/applications/org.gnome.orca"
   "enableEchoByCharacter": true
   "enableEchoByWord": true
   ; volumeTTS * 10
-  "voices.default.gain": 3.5
+  "voices.default.gain": 7.5
   ; pitch * 10 (Orca default: 5.0)
-  "voices.default.average-pitch": 4.0
+  "voices.default.average-pitch": 8.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
@@ -66,13 +62,13 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "en"
   _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "en"
   _disabled=true
 
 
@@ -86,57 +82,25 @@ app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "screenReaderBrailleOutput": false
   "screenReaderTTSEnabled": true
-  "speechRate": 99
+  "speechRate": 137.6
   "punctuationVerbosity": "all"
-  "announceCapitals": true
+  "announceCapitals": false
   ; keyEcho and wordEcho
   "keyEcho": true
   "wordEcho": true
-  _disabled=true
 
 
 ; Mobile Accessibility for Android (CodeFactory)
 [preferences]
 app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
-  "access_commonprefs_speechrate": 4.03
+  "access_commonprefs_speechrate": 5.5
   ; punctuationVerbosity
   "access_commonprefs_punctuation": "all"
   ; announceCapitals
-  "access_commonprefs_capitalization": true
+  "access_commonprefs_capitalization": false
   ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
   "access_commonprefs_editingkeyboardecho": 3
   ; pitch * 10 (MAA default : 5)
-  "access_commonprefs_speechpitch": 4
-  _disabled=true
+  "access_commonprefs_speechpitch": 8
 
-
-; Android with TalkBack (FVE)
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.freespeech"
-  ; just start freespeech
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.talkback"
-  ; just start talkback
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
-  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
-  "locale": "fr"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.audioManager"
-  ; volumeTTS * 15
-  "STREAM_MUSIC": 5.25
-
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.system"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.secure"
-  ; @@relationship to WPM not well established!!
-  "tts_default_rate": 160
-  ; pitch * 500 (Android default: 100)
-  "tts_default_pitch": 200
 

--- a/manualDataThirdPhase/screenreader_250.ini
+++ b/manualDataThirdPhase/screenreader_250.ini
@@ -1,0 +1,141 @@
+; screen reader settings on Windows, Linux, Android, ...
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_250"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 250
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 54.84
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 0
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": False
+  "keyboard.speakTypedWords": False
+  ; volumeTTS * 100
+  "speech.espeak.volume": 60
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 90
+
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  "voices.default.rate": 80
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 3
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": false
+  "enableEchoByWord": false
+  ; volumeTTS * 10
+  "voices.default.gain": 6
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 9.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
+  "always-show-universal-access-status": true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
+  ; auditoryOutLanguage
+  "locale": "en"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
+  ; auditoryOutLanguage
+  "locale": "en"
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "screenReaderTTSEnabled": true
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "screenReaderBrailleOutput": false
+  "screenReaderTTSEnabled": true
+  "speechRate": 157
+  "punctuationVerbosity": "none"
+  "announceCapitals": true
+  ; keyEcho and wordEcho
+  "keyEcho": false
+  "wordEcho": false
+
+
+
+; Mobile Accessibility for Android (CodeFactory)
+[preferences]
+app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
+  "access_commonprefs_speechrate": 6.25
+  ; punctuationVerbosity
+  "access_commonprefs_punctuation": "none"
+  ; announceCapitals
+  "access_commonprefs_capitalization": true
+  ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
+  "access_commonprefs_editingkeyboardecho": 0
+  ; pitch * 10 (MAA default : 5)
+  "access_commonprefs_speechpitch": 9
+
+
+; Android with TalkBack (FVE)
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.freespeech"
+  ; just start freespeech
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.talkback"
+  ; just start talkback
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
+  "locale": "en_GB"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volumeTTS * 15
+  "STREAM_MUSIC": 9
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.secure"
+  ; @@relationship to WPM not well established!!
+  "tts_default_rate": 250
+  ; pitch * 500 (Android default: 100)
+  "tts_default_pitch": 450

--- a/manualDataThirdPhase/screenreader_250.ini
+++ b/manualDataThirdPhase/screenreader_250.ini
@@ -108,6 +108,7 @@ app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
   "access_commonprefs_editingkeyboardecho": 0
   ; pitch * 10 (MAA default : 5)
   "access_commonprefs_speechpitch": 9
+  _disabled=true
 
 
 ; Android with TalkBack (FVE)
@@ -139,3 +140,4 @@ app = "http://registry.gpii.net/applications/com.android.settings.secure"
   "tts_default_rate": 250
   ; pitch * 500 (Android default: 100)
   "tts_default_pitch": 450
+

--- a/manualDataThirdPhase/screenreader_250_m11y.ini
+++ b/manualDataThirdPhase/screenreader_250_m11y.ini
@@ -1,12 +1,12 @@
 ; screen reader settings on Windows, Linux, Android, ...
 ; screen reader with TTS; Braille is disabled
 [context]
-user = "screenreader_160"
+user = "screenreader_250_m11y"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
-  speechRate = 160
+  speechRate = 250
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
@@ -15,48 +15,49 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; screenReaderTTSEnabled
   "speech.synth": "espeak"
   "speech.outputDevice": "Microsoft Sound Mapper"
-  "speech.espeak.rate": 25.81
+  "speech.espeak.rate": 54.84
   ; auditoryOutLanguage
-  "speech.espeak.voice": "fr"
+  "speech.espeak.voice": "en\\en"
   ; trackingTTS
   "reviewCursor.followFocus": True
   "reviewCursor.followCaret": True
   "reviewCursor.followMouse": True
   ; punctuationVerbosity (default: some = 100)
-  "speech.symbolLevel": 300
+  "speech.symbolLevel": 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
   "virtualBuffers.autoSayAllOnPageLoad": True
   ; announceCapitals
   "speech.espeak.sayCapForCapitals": True
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters": True
-  "keyboard.speakTypedWords": True
+  "keyboard.speakTypedCharacters": False
+  "keyboard.speakTypedWords": False
   ; volumeTTS * 100
-  "speech.espeak.volume": 35
+  "speech.espeak.volume": 60
   ; pitch * 100 (NVDA default = 40)
-  "speech.espeak.pitch": 40
+  "speech.espeak.pitch": 90
+
 
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.orca"
   "enableBraille": false
   "enableSpeech": true
-  "voices.default.rate": 50
+  "voices.default.rate": 80
   ; auditoryOutLanguage
-  "voices.default.family.locale": "fr"
-  "voices.default.family.name": "french"
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
   ; punctuationVerbosity (some = 2)
-  "verbalizePunctuationStyle": 0
+  "verbalizePunctuationStyle": 3
   ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
   "sayAllStyle": 1
   ; announceCapitals: not supported
   ; keyEcho and wordEcho
-  "enableEchoByCharacter": true
-  "enableEchoByWord": true
+  "enableEchoByCharacter": false
+  "enableEchoByWord": false
   ; volumeTTS * 10
-  "voices.default.gain": 3.5
+  "voices.default.gain": 6
   ; pitch * 10 (Orca default: 5.0)
-  "voices.default.average-pitch": 4.0
+  "voices.default.average-pitch": 9.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
@@ -66,13 +67,13 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "en"
   _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "en"
   _disabled=true
 
 
@@ -86,57 +87,26 @@ app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "screenReaderBrailleOutput": false
   "screenReaderTTSEnabled": true
-  "speechRate": 99
-  "punctuationVerbosity": "all"
+  "speechRate": 157
+  "punctuationVerbosity": "none"
   "announceCapitals": true
   ; keyEcho and wordEcho
-  "keyEcho": true
-  "wordEcho": true
-  _disabled=true
+  "keyEcho": false
+  "wordEcho": false
+
 
 
 ; Mobile Accessibility for Android (CodeFactory)
 [preferences]
 app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
-  "access_commonprefs_speechrate": 4.03
+  "access_commonprefs_speechrate": 6.25
   ; punctuationVerbosity
-  "access_commonprefs_punctuation": "all"
+  "access_commonprefs_punctuation": "none"
   ; announceCapitals
   "access_commonprefs_capitalization": true
   ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
-  "access_commonprefs_editingkeyboardecho": 3
+  "access_commonprefs_editingkeyboardecho": 0
   ; pitch * 10 (MAA default : 5)
-  "access_commonprefs_speechpitch": 4
-  _disabled=true
+  "access_commonprefs_speechpitch": 9
 
-
-; Android with TalkBack (FVE)
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.freespeech"
-  ; just start freespeech
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.talkback"
-  ; just start talkback
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
-  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
-  "locale": "fr"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.audioManager"
-  ; volumeTTS * 15
-  "STREAM_MUSIC": 5.25
-
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.system"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.secure"
-  ; @@relationship to WPM not well established!!
-  "tts_default_rate": 160
-  ; pitch * 500 (Android default: 100)
-  "tts_default_pitch": 200
 

--- a/manualDataThirdPhase/screenreader_280.ini
+++ b/manualDataThirdPhase/screenreader_280.ini
@@ -106,6 +106,7 @@ app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
   "access_commonprefs_editingkeyboardecho": 2
   ; pitch * 10 (MAA default : 5)
   "access_commonprefs_speechpitch": 10
+  _disabled=true
 
 
 ; Android with TalkBack (FVE)
@@ -137,3 +138,4 @@ app = "http://registry.gpii.net/applications/com.android.settings.secure"
   "tts_default_rate": 280
   ; pitch * 500 (Android default: 100)
   "tts_default_pitch": 500
+

--- a/manualDataThirdPhase/screenreader_280.ini
+++ b/manualDataThirdPhase/screenreader_280.ini
@@ -1,0 +1,139 @@
+; screen reader settings on Windows, Linux, Android, ...
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_280"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 280
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 64.52
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en-us"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": False
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 45
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 10
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  "voices.default.rate": 90
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english-us"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 2
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": false
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 4.5
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 10.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
+  "always-show-universal-access-status": true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
+  ; auditoryOutLanguage
+  "locale": "en"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
+  ; auditoryOutLanguage
+  "locale": "en"
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "screenReaderTTSEnabled": true
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "screenReaderBrailleOutput": false
+  "screenReaderTTSEnabled": true
+  "speechRate": 176
+  "punctuationVerbosity": "some"
+  "announceCapitals": true
+  ; keyEcho and wordEcho
+  "keyEcho": false
+  "wordEcho": true
+
+
+; Mobile Accessibility for Android (CodeFactory)
+[preferences]
+app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
+  "access_commonprefs_speechrate": 7
+  ; punctuationVerbosity
+  "access_commonprefs_punctuation": "some"
+  ; announceCapitals
+  "access_commonprefs_capitalization": true
+  ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
+  "access_commonprefs_editingkeyboardecho": 2
+  ; pitch * 10 (MAA default : 5)
+  "access_commonprefs_speechpitch": 10
+
+
+; Android with TalkBack (FVE)
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.freespeech"
+  ; just start freespeech
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.talkback"
+  ; just start talkback
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
+  "locale": "en_US"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volumeTTS * 15
+  "STREAM_MUSIC": 6.75
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.secure"
+  ; @@relationship to WPM not well established!!
+  "tts_default_rate": 280
+  ; pitch * 500 (Android default: 100)
+  "tts_default_pitch": 500

--- a/manualDataThirdPhase/screenreader_280_m11y.ini
+++ b/manualDataThirdPhase/screenreader_280_m11y.ini
@@ -1,12 +1,12 @@
 ; screen reader settings on Windows, Linux, Android, ...
 ; screen reader with TTS; Braille is disabled
 [context]
-user = "screenreader_160"
+user = "screenreader_280_m11y"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
-  speechRate = 160
+  speechRate = 280
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
@@ -15,48 +15,48 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; screenReaderTTSEnabled
   "speech.synth": "espeak"
   "speech.outputDevice": "Microsoft Sound Mapper"
-  "speech.espeak.rate": 25.81
+  "speech.espeak.rate": 64.52
   ; auditoryOutLanguage
-  "speech.espeak.voice": "fr"
+  "speech.espeak.voice": "en\\en-us"
   ; trackingTTS
   "reviewCursor.followFocus": True
   "reviewCursor.followCaret": True
   "reviewCursor.followMouse": True
   ; punctuationVerbosity (default: some = 100)
-  "speech.symbolLevel": 300
+  "speech.symbolLevel": 100
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
   "virtualBuffers.autoSayAllOnPageLoad": True
   ; announceCapitals
   "speech.espeak.sayCapForCapitals": True
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedCharacters": False
   "keyboard.speakTypedWords": True
   ; volumeTTS * 100
-  "speech.espeak.volume": 35
+  "speech.espeak.volume": 45
   ; pitch * 100 (NVDA default = 40)
-  "speech.espeak.pitch": 40
+  "speech.espeak.pitch": 10
 
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.orca"
   "enableBraille": false
   "enableSpeech": true
-  "voices.default.rate": 50
+  "voices.default.rate": 90
   ; auditoryOutLanguage
-  "voices.default.family.locale": "fr"
-  "voices.default.family.name": "french"
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english-us"
   ; punctuationVerbosity (some = 2)
-  "verbalizePunctuationStyle": 0
+  "verbalizePunctuationStyle": 2
   ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
   "sayAllStyle": 1
   ; announceCapitals: not supported
   ; keyEcho and wordEcho
-  "enableEchoByCharacter": true
+  "enableEchoByCharacter": false
   "enableEchoByWord": true
   ; volumeTTS * 10
-  "voices.default.gain": 3.5
+  "voices.default.gain": 4.5
   ; pitch * 10 (Orca default: 5.0)
-  "voices.default.average-pitch": 4.0
+  "voices.default.average-pitch": 10.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
@@ -66,13 +66,13 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "en"
   _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "en"
   _disabled=true
 
 
@@ -86,57 +86,25 @@ app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "screenReaderBrailleOutput": false
   "screenReaderTTSEnabled": true
-  "speechRate": 99
-  "punctuationVerbosity": "all"
+  "speechRate": 176
+  "punctuationVerbosity": "some"
   "announceCapitals": true
   ; keyEcho and wordEcho
-  "keyEcho": true
+  "keyEcho": false
   "wordEcho": true
-  _disabled=true
 
 
 ; Mobile Accessibility for Android (CodeFactory)
 [preferences]
 app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
-  "access_commonprefs_speechrate": 4.03
+  "access_commonprefs_speechrate": 7
   ; punctuationVerbosity
-  "access_commonprefs_punctuation": "all"
+  "access_commonprefs_punctuation": "some"
   ; announceCapitals
   "access_commonprefs_capitalization": true
   ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
-  "access_commonprefs_editingkeyboardecho": 3
+  "access_commonprefs_editingkeyboardecho": 2
   ; pitch * 10 (MAA default : 5)
-  "access_commonprefs_speechpitch": 4
-  _disabled=true
+  "access_commonprefs_speechpitch": 10
 
-
-; Android with TalkBack (FVE)
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.freespeech"
-  ; just start freespeech
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.talkback"
-  ; just start talkback
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
-  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
-  "locale": "fr"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.audioManager"
-  ; volumeTTS * 15
-  "STREAM_MUSIC": 5.25
-
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.system"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.secure"
-  ; @@relationship to WPM not well established!!
-  "tts_default_rate": 160
-  ; pitch * 500 (Android default: 100)
-  "tts_default_pitch": 200
 

--- a/manualDataThirdPhase/screenreader_310.ini
+++ b/manualDataThirdPhase/screenreader_310.ini
@@ -106,6 +106,7 @@ app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
   "access_commonprefs_editingkeyboardecho": 3
   ; pitch * 10 (MAA default : 5)
   "access_commonprefs_speechpitch": 1
+  _disabled=true
 
 
 ; Android with TalkBack (FVE)
@@ -137,3 +138,4 @@ app = "http://registry.gpii.net/applications/com.android.settings.secure"
   "tts_default_rate": 310
   ; pitch * 500 (Android default: 100)
   "tts_default_pitch": 50
+

--- a/manualDataThirdPhase/screenreader_310.ini
+++ b/manualDataThirdPhase/screenreader_310.ini
@@ -1,0 +1,139 @@
+; screen reader settings on Windows, Linux, Android, ...
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_310"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 310
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 74.19
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "de"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 30
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 10
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "de"
+  "voices.default.family.name": "german"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 3
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 1.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
+  "always-show-universal-access-status": true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
+  ; auditoryOutLanguage
+  "locale": "de"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
+  ; auditoryOutLanguage
+  "locale": "de"
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "screenReaderTTSEnabled": true
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "screenReaderBrailleOutput": false
+  "screenReaderTTSEnabled": true
+  "speechRate": 195
+  "punctuationVerbosity": "most"
+  "announceCapitals": true
+  ; keyEcho and wordEcho
+  "keyEcho": true
+  "wordEcho": true
+
+
+; Mobile Accessibility for Android (CodeFactory)
+[preferences]
+app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
+  "access_commonprefs_speechrate": 7.75
+  ; punctuationVerbosity
+  "access_commonprefs_punctuation": "most"
+  ; announceCapitals
+  "access_commonprefs_capitalization": true
+  ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
+  "access_commonprefs_editingkeyboardecho": 3
+  ; pitch * 10 (MAA default : 5)
+  "access_commonprefs_speechpitch": 1
+
+
+; Android with TalkBack (FVE)
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.freespeech"
+  ; just start freespeech
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.talkback"
+  ; just start talkback
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
+  "locale": "de"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volumeTTS * 15
+  "STREAM_MUSIC": 4.5
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.secure"
+  ; @@relationship to WPM not well established!!
+  "tts_default_rate": 310
+  ; pitch * 500 (Android default: 100)
+  "tts_default_pitch": 50

--- a/manualDataThirdPhase/screenreader_310_m11y.ini
+++ b/manualDataThirdPhase/screenreader_310_m11y.ini
@@ -1,12 +1,12 @@
 ; screen reader settings on Windows, Linux, Android, ...
 ; screen reader with TTS; Braille is disabled
 [context]
-user = "screenreader_160"
+user = "screenreader_310_m11y"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
-  speechRate = 160
+  speechRate = 310
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
@@ -15,15 +15,15 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; screenReaderTTSEnabled
   "speech.synth": "espeak"
   "speech.outputDevice": "Microsoft Sound Mapper"
-  "speech.espeak.rate": 25.81
+  "speech.espeak.rate": 74.19
   ; auditoryOutLanguage
-  "speech.espeak.voice": "fr"
+  "speech.espeak.voice": "de"
   ; trackingTTS
   "reviewCursor.followFocus": True
   "reviewCursor.followCaret": True
   "reviewCursor.followMouse": True
   ; punctuationVerbosity (default: some = 100)
-  "speech.symbolLevel": 300
+  "speech.symbolLevel": 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
   "virtualBuffers.autoSayAllOnPageLoad": True
   ; announceCapitals
@@ -32,21 +32,21 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   "keyboard.speakTypedCharacters": True
   "keyboard.speakTypedWords": True
   ; volumeTTS * 100
-  "speech.espeak.volume": 35
+  "speech.espeak.volume": 30
   ; pitch * 100 (NVDA default = 40)
-  "speech.espeak.pitch": 40
+  "speech.espeak.pitch": 10
 
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.orca"
   "enableBraille": false
   "enableSpeech": true
-  "voices.default.rate": 50
+  "voices.default.rate": 100
   ; auditoryOutLanguage
-  "voices.default.family.locale": "fr"
-  "voices.default.family.name": "french"
+  "voices.default.family.locale": "de"
+  "voices.default.family.name": "german"
   ; punctuationVerbosity (some = 2)
-  "verbalizePunctuationStyle": 0
+  "verbalizePunctuationStyle": 1
   ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
   "sayAllStyle": 1
   ; announceCapitals: not supported
@@ -54,9 +54,9 @@ app = "http://registry.gpii.net/applications/org.gnome.orca"
   "enableEchoByCharacter": true
   "enableEchoByWord": true
   ; volumeTTS * 10
-  "voices.default.gain": 3.5
+  "voices.default.gain": 3
   ; pitch * 10 (Orca default: 5.0)
-  "voices.default.average-pitch": 4.0
+  "voices.default.average-pitch": 1.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
@@ -66,13 +66,13 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "de"
   _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "de"
   _disabled=true
 
 
@@ -86,57 +86,25 @@ app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "screenReaderBrailleOutput": false
   "screenReaderTTSEnabled": true
-  "speechRate": 99
-  "punctuationVerbosity": "all"
+  "speechRate": 195
+  "punctuationVerbosity": "most"
   "announceCapitals": true
   ; keyEcho and wordEcho
   "keyEcho": true
   "wordEcho": true
-  _disabled=true
 
 
 ; Mobile Accessibility for Android (CodeFactory)
 [preferences]
 app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
-  "access_commonprefs_speechrate": 4.03
+  "access_commonprefs_speechrate": 7.75
   ; punctuationVerbosity
-  "access_commonprefs_punctuation": "all"
+  "access_commonprefs_punctuation": "most"
   ; announceCapitals
   "access_commonprefs_capitalization": true
   ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
   "access_commonprefs_editingkeyboardecho": 3
   ; pitch * 10 (MAA default : 5)
-  "access_commonprefs_speechpitch": 4
-  _disabled=true
+  "access_commonprefs_speechpitch": 1
 
-
-; Android with TalkBack (FVE)
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.freespeech"
-  ; just start freespeech
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.talkback"
-  ; just start talkback
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
-  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
-  "locale": "fr"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.audioManager"
-  ; volumeTTS * 15
-  "STREAM_MUSIC": 5.25
-
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.system"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.secure"
-  ; @@relationship to WPM not well established!!
-  "tts_default_rate": 160
-  ; pitch * 500 (Android default: 100)
-  "tts_default_pitch": 200
 

--- a/manualDataThirdPhase/screenreader_320.ini
+++ b/manualDataThirdPhase/screenreader_320.ini
@@ -107,6 +107,7 @@ app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
   "access_commonprefs_editingkeyboardecho": 0
   ; pitch * 10 (MAA default : 5)
   "access_commonprefs_speechpitch": 2
+  _disabled=true
 
 
 ; Android with TalkBack (FVE)
@@ -138,3 +139,4 @@ app = "http://registry.gpii.net/applications/com.android.settings.secure"
   "tts_default_rate": 320
   ; pitch * 500 (Android default: 100)
   "tts_default_pitch": 100
+

--- a/manualDataThirdPhase/screenreader_320.ini
+++ b/manualDataThirdPhase/screenreader_320.ini
@@ -1,0 +1,140 @@
+; screen reader settings on Windows, Linux, Android, ...
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_320"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 320
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 77.42
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "de"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 300
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": False
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": False
+  "keyboard.speakTypedWords": False
+  ; volumeTTS * 100
+  "speech.espeak.volume": 15
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 20
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "de"
+  "voices.default.family.name": "german"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 0
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": false
+  "enableEchoByWord": false
+  ; volumeTTS * 10
+  "voices.default.gain": 1.5
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 2.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
+  "always-show-universal-access-status": true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
+  ; auditoryOutLanguage
+  "locale": "de"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
+  ; auditoryOutLanguage
+  "locale": "de"
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "screenReaderTTSEnabled": true
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "screenReaderBrailleOutput": false
+  "screenReaderTTSEnabled": true
+  "speechRate": 202
+  "punctuationVerbosity": "all"
+  "announceCapitals": false
+  ; keyEcho and wordEcho
+  "keyEcho": false
+  "wordEcho": false
+
+
+; Mobile Accessibility for Android (CodeFactory)
+[preferences]
+app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
+  "access_commonprefs_speechrate": 8
+  ; punctuationVerbosity
+  "access_commonprefs_punctuation": "all"
+  ; announceCapitals
+  "access_commonprefs_capitalization": false
+  ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
+  "access_commonprefs_editingkeyboardecho": 0
+  ; pitch * 10 (MAA default : 5)
+  "access_commonprefs_speechpitch": 2
+
+
+; Android with TalkBack (FVE)
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.freespeech"
+  ; just start freespeech
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.talkback"
+  ; just start talkback
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
+  "locale": "de_DE"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volumeTTS * 15
+  "STREAM_MUSIC": 2.25
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.secure"
+  ; @@relationship to WPM not well established!!
+  "tts_default_rate": 320
+  ; pitch * 500 (Android default: 100)
+  "tts_default_pitch": 100

--- a/manualDataThirdPhase/screenreader_320_m11y.ini
+++ b/manualDataThirdPhase/screenreader_320_m11y.ini
@@ -1,12 +1,12 @@
 ; screen reader settings on Windows, Linux, Android, ...
 ; screen reader with TTS; Braille is disabled
 [context]
-user = "screenreader_160"
+user = "screenreader_320_m11y"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
-  speechRate = 160
+  speechRate = 320
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
@@ -15,9 +15,9 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; screenReaderTTSEnabled
   "speech.synth": "espeak"
   "speech.outputDevice": "Microsoft Sound Mapper"
-  "speech.espeak.rate": 25.81
+  "speech.espeak.rate": 77.42
   ; auditoryOutLanguage
-  "speech.espeak.voice": "fr"
+  "speech.espeak.voice": "de"
   ; trackingTTS
   "reviewCursor.followFocus": True
   "reviewCursor.followCaret": True
@@ -27,36 +27,37 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
   "virtualBuffers.autoSayAllOnPageLoad": True
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals": True
+  "speech.espeak.sayCapForCapitals": False
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters": True
-  "keyboard.speakTypedWords": True
+  "keyboard.speakTypedCharacters": False
+  "keyboard.speakTypedWords": False
   ; volumeTTS * 100
-  "speech.espeak.volume": 35
+  "speech.espeak.volume": 15
   ; pitch * 100 (NVDA default = 40)
-  "speech.espeak.pitch": 40
+  "speech.espeak.pitch": 20
 
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.orca"
   "enableBraille": false
   "enableSpeech": true
-  "voices.default.rate": 50
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
   ; auditoryOutLanguage
-  "voices.default.family.locale": "fr"
-  "voices.default.family.name": "french"
+  "voices.default.family.locale": "de"
+  "voices.default.family.name": "german"
   ; punctuationVerbosity (some = 2)
   "verbalizePunctuationStyle": 0
   ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
   "sayAllStyle": 1
   ; announceCapitals: not supported
   ; keyEcho and wordEcho
-  "enableEchoByCharacter": true
-  "enableEchoByWord": true
+  "enableEchoByCharacter": false
+  "enableEchoByWord": false
   ; volumeTTS * 10
-  "voices.default.gain": 3.5
+  "voices.default.gain": 1.5
   ; pitch * 10 (Orca default: 5.0)
-  "voices.default.average-pitch": 4.0
+  "voices.default.average-pitch": 2.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
@@ -66,13 +67,13 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "de"
   _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "de"
   _disabled=true
 
 
@@ -86,57 +87,25 @@ app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "screenReaderBrailleOutput": false
   "screenReaderTTSEnabled": true
-  "speechRate": 99
+  "speechRate": 202
   "punctuationVerbosity": "all"
-  "announceCapitals": true
+  "announceCapitals": false
   ; keyEcho and wordEcho
-  "keyEcho": true
-  "wordEcho": true
-  _disabled=true
+  "keyEcho": false
+  "wordEcho": false
 
 
 ; Mobile Accessibility for Android (CodeFactory)
 [preferences]
 app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
-  "access_commonprefs_speechrate": 4.03
+  "access_commonprefs_speechrate": 8
   ; punctuationVerbosity
   "access_commonprefs_punctuation": "all"
   ; announceCapitals
-  "access_commonprefs_capitalization": true
+  "access_commonprefs_capitalization": false
   ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
-  "access_commonprefs_editingkeyboardecho": 3
+  "access_commonprefs_editingkeyboardecho": 0
   ; pitch * 10 (MAA default : 5)
-  "access_commonprefs_speechpitch": 4
-  _disabled=true
+  "access_commonprefs_speechpitch": 2
 
-
-; Android with TalkBack (FVE)
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.freespeech"
-  ; just start freespeech
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.talkback"
-  ; just start talkback
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
-  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
-  "locale": "fr"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.audioManager"
-  ; volumeTTS * 15
-  "STREAM_MUSIC": 5.25
-
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.system"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.secure"
-  ; @@relationship to WPM not well established!!
-  "tts_default_rate": 160
-  ; pitch * 500 (Android default: 100)
-  "tts_default_pitch": 200
 

--- a/manualDataThirdPhase/screenreader_360.ini
+++ b/manualDataThirdPhase/screenreader_360.ini
@@ -107,6 +107,7 @@ app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
   "access_commonprefs_editingkeyboardecho": 1
   ; pitch * 10 (MAA default : 5)
   "access_commonprefs_speechpitch": 3
+  _disabled=true
 
 
 ; Android with TalkBack (FVE)
@@ -138,3 +139,4 @@ app = "http://registry.gpii.net/applications/com.android.settings.secure"
   "tts_default_rate": 227.5
   ; pitch * 500 (Android default: 100)
   "tts_default_pitch": 150
+

--- a/manualDataThirdPhase/screenreader_360.ini
+++ b/manualDataThirdPhase/screenreader_360.ini
@@ -1,0 +1,140 @@
+; screen reader settings on Windows, Linux, Android, ...
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_360"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 360
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 90.32
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "el"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 0
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": False
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": False
+  ; volumeTTS * 100
+  "speech.espeak.volume": 100
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 30
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "el"
+  "voices.default.family.name": "greek"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 3
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": false
+  ; volumeTTS * 10
+  "voices.default.gain": 10
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 3.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
+  "always-show-universal-access-status": true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
+  ; auditoryOutLanguage
+  "locale": "el"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
+  ; auditoryOutLanguage
+  "locale": "el"
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "screenReaderTTSEnabled": true
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "screenReaderBrailleOutput": false
+  "screenReaderTTSEnabled": true
+  "speechRate": 360
+  "punctuationVerbosity": "none"
+  "announceCapitals": false
+  ; keyEcho and wordEcho
+  "keyEcho": true
+  "wordEcho": false
+
+
+; Mobile Accessibility for Android (CodeFactory)
+[preferences]
+app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
+  "access_commonprefs_speechrate": 9
+  ; punctuationVerbosity
+  "access_commonprefs_punctuation": "none"
+  ; announceCapitals
+  "access_commonprefs_capitalization": false
+  ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
+  "access_commonprefs_editingkeyboardecho": 1
+  ; pitch * 10 (MAA default : 5)
+  "access_commonprefs_speechpitch": 3
+
+
+; Android with TalkBack (FVE)
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.freespeech"
+  ; just start freespeech
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.talkback"
+  ; just start talkback
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
+  "locale": "el"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volumeTTS * 15
+  "STREAM_MUSIC": 15
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.secure"
+  ; @@relationship to WPM not well established!!
+  "tts_default_rate": 227.5
+  ; pitch * 500 (Android default: 100)
+  "tts_default_pitch": 150

--- a/manualDataThirdPhase/screenreader_360_m11y.ini
+++ b/manualDataThirdPhase/screenreader_360_m11y.ini
@@ -1,12 +1,12 @@
 ; screen reader settings on Windows, Linux, Android, ...
 ; screen reader with TTS; Braille is disabled
 [context]
-user = "screenreader_160"
+user = "screenreader_360_m11y"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
-  speechRate = 160
+  speechRate = 360
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
@@ -15,48 +15,49 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; screenReaderTTSEnabled
   "speech.synth": "espeak"
   "speech.outputDevice": "Microsoft Sound Mapper"
-  "speech.espeak.rate": 25.81
+  "speech.espeak.rate": 90.32
   ; auditoryOutLanguage
-  "speech.espeak.voice": "fr"
+  "speech.espeak.voice": "el"
   ; trackingTTS
   "reviewCursor.followFocus": True
   "reviewCursor.followCaret": True
   "reviewCursor.followMouse": True
   ; punctuationVerbosity (default: some = 100)
-  "speech.symbolLevel": 300
+  "speech.symbolLevel": 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
   "virtualBuffers.autoSayAllOnPageLoad": True
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals": True
+  "speech.espeak.sayCapForCapitals": False
   ; keyEcho and wordEcho
   "keyboard.speakTypedCharacters": True
-  "keyboard.speakTypedWords": True
+  "keyboard.speakTypedWords": False
   ; volumeTTS * 100
-  "speech.espeak.volume": 35
+  "speech.espeak.volume": 100
   ; pitch * 100 (NVDA default = 40)
-  "speech.espeak.pitch": 40
+  "speech.espeak.pitch": 30
 
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.orca"
   "enableBraille": false
   "enableSpeech": true
-  "voices.default.rate": 50
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
   ; auditoryOutLanguage
-  "voices.default.family.locale": "fr"
-  "voices.default.family.name": "french"
+  "voices.default.family.locale": "el"
+  "voices.default.family.name": "greek"
   ; punctuationVerbosity (some = 2)
-  "verbalizePunctuationStyle": 0
+  "verbalizePunctuationStyle": 3
   ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
   "sayAllStyle": 1
   ; announceCapitals: not supported
   ; keyEcho and wordEcho
   "enableEchoByCharacter": true
-  "enableEchoByWord": true
+  "enableEchoByWord": false
   ; volumeTTS * 10
-  "voices.default.gain": 3.5
+  "voices.default.gain": 10
   ; pitch * 10 (Orca default: 5.0)
-  "voices.default.average-pitch": 4.0
+  "voices.default.average-pitch": 3.0
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
@@ -66,13 +67,13 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "el"
   _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "el"
   _disabled=true
 
 
@@ -86,57 +87,25 @@ app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "screenReaderBrailleOutput": false
   "screenReaderTTSEnabled": true
-  "speechRate": 99
-  "punctuationVerbosity": "all"
-  "announceCapitals": true
+  "speechRate": 360
+  "punctuationVerbosity": "none"
+  "announceCapitals": false
   ; keyEcho and wordEcho
   "keyEcho": true
-  "wordEcho": true
-  _disabled=true
+  "wordEcho": false
 
 
 ; Mobile Accessibility for Android (CodeFactory)
 [preferences]
 app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
-  "access_commonprefs_speechrate": 4.03
+  "access_commonprefs_speechrate": 9
   ; punctuationVerbosity
-  "access_commonprefs_punctuation": "all"
+  "access_commonprefs_punctuation": "none"
   ; announceCapitals
-  "access_commonprefs_capitalization": true
+  "access_commonprefs_capitalization": false
   ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
-  "access_commonprefs_editingkeyboardecho": 3
+  "access_commonprefs_editingkeyboardecho": 1
   ; pitch * 10 (MAA default : 5)
-  "access_commonprefs_speechpitch": 4
-  _disabled=true
+  "access_commonprefs_speechpitch": 3
 
-
-; Android with TalkBack (FVE)
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.freespeech"
-  ; just start freespeech
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.talkback"
-  ; just start talkback
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
-  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
-  "locale": "fr"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.audioManager"
-  ; volumeTTS * 15
-  "STREAM_MUSIC": 5.25
-
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.system"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.secure"
-  ; @@relationship to WPM not well established!!
-  "tts_default_rate": 160
-  ; pitch * 500 (Android default: 100)
-  "tts_default_pitch": 200
 

--- a/manualDataThirdPhase/screenreader_390.ini
+++ b/manualDataThirdPhase/screenreader_390.ini
@@ -1,0 +1,140 @@
+; screen reader settings on Windows, Linux, Android, ...
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_390"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 390
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 100
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "es"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": False
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": False
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 85
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 40
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "es"
+  "voices.default.family.name": "spanish"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": false
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 8.5
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 4.0
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
+  "always-show-universal-access-status": true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
+  ; auditoryOutLanguage
+  "locale": "es"
+  _disabled=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
+  ; auditoryOutLanguage
+  "locale": "es"
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
+  "screenReaderTTSEnabled": true
+  _disabled=true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  "screenReaderBrailleOutput": false
+  "screenReaderTTSEnabled": true
+  "speechRate": 247.5
+  "punctuationVerbosity": "some"
+  "announceCapitals": false
+  ; keyEcho and wordEcho
+  "keyEcho": false
+  "wordEcho": true
+
+
+; Mobile Accessibility for Android (CodeFactory)
+[preferences]
+app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
+  "access_commonprefs_speechrate": 9.75
+  ; punctuationVerbosity
+  "access_commonprefs_punctuation": "some"
+  ; announceCapitals
+  "access_commonprefs_capitalization": false
+  ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
+  "access_commonprefs_editingkeyboardecho": 2
+  ; pitch * 10 (MAA default : 5)
+  "access_commonprefs_speechpitch": 4
+
+
+; Android with TalkBack (FVE)
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.freespeech"
+  ; just start freespeech
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.talkback"
+  ; just start talkback
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
+  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
+  "locale": "es"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.audioManager"
+  ; volumeTTS * 15
+  "STREAM_MUSIC": 12.75
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.system"
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.android.settings.secure"
+  ; @@relationship to WPM not well established!!
+  "tts_default_rate": 390
+  ; pitch * 500 (Android default: 100)
+  "tts_default_pitch": 200

--- a/manualDataThirdPhase/screenreader_390.ini
+++ b/manualDataThirdPhase/screenreader_390.ini
@@ -107,6 +107,7 @@ app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
   "access_commonprefs_editingkeyboardecho": 2
   ; pitch * 10 (MAA default : 5)
   "access_commonprefs_speechpitch": 4
+  _disabled=true
 
 
 ; Android with TalkBack (FVE)
@@ -138,3 +139,4 @@ app = "http://registry.gpii.net/applications/com.android.settings.secure"
   "tts_default_rate": 390
   ; pitch * 500 (Android default: 100)
   "tts_default_pitch": 200
+

--- a/manualDataThirdPhase/screenreader_390_m11y.ini
+++ b/manualDataThirdPhase/screenreader_390_m11y.ini
@@ -1,12 +1,12 @@
 ; screen reader settings on Windows, Linux, Android, ...
 ; screen reader with TTS; Braille is disabled
 [context]
-user = "screenreader_160"
+user = "screenreader_390_m11y"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
-  speechRate = 160
+  speechRate = 390
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
@@ -15,24 +15,24 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; screenReaderTTSEnabled
   "speech.synth": "espeak"
   "speech.outputDevice": "Microsoft Sound Mapper"
-  "speech.espeak.rate": 25.81
+  "speech.espeak.rate": 100
   ; auditoryOutLanguage
-  "speech.espeak.voice": "fr"
+  "speech.espeak.voice": "es"
   ; trackingTTS
   "reviewCursor.followFocus": True
   "reviewCursor.followCaret": True
   "reviewCursor.followMouse": True
   ; punctuationVerbosity (default: some = 100)
-  "speech.symbolLevel": 300
+  "speech.symbolLevel": 100
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
   "virtualBuffers.autoSayAllOnPageLoad": True
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals": True
+  "speech.espeak.sayCapForCapitals": False
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedCharacters": False
   "keyboard.speakTypedWords": True
   ; volumeTTS * 100
-  "speech.espeak.volume": 35
+  "speech.espeak.volume": 85
   ; pitch * 100 (NVDA default = 40)
   "speech.espeak.pitch": 40
 
@@ -41,20 +41,21 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 app = "http://registry.gpii.net/applications/org.gnome.orca"
   "enableBraille": false
   "enableSpeech": true
-  "voices.default.rate": 50
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
   ; auditoryOutLanguage
-  "voices.default.family.locale": "fr"
-  "voices.default.family.name": "french"
+  "voices.default.family.locale": "es"
+  "voices.default.family.name": "spanish"
   ; punctuationVerbosity (some = 2)
-  "verbalizePunctuationStyle": 0
+  "verbalizePunctuationStyle": 1
   ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
   "sayAllStyle": 1
   ; announceCapitals: not supported
   ; keyEcho and wordEcho
-  "enableEchoByCharacter": true
+  "enableEchoByCharacter": false
   "enableEchoByWord": true
   ; volumeTTS * 10
-  "voices.default.gain": 3.5
+  "voices.default.gain": 8.5
   ; pitch * 10 (Orca default: 5.0)
   "voices.default.average-pitch": 4.0
 
@@ -66,13 +67,13 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y"
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.windows"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "es"
   _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/webinsight.webAnywhere.linux"
   ; auditoryOutLanguage
-  "locale": "fr"
+  "locale": "es"
   _disabled=true
 
 
@@ -86,57 +87,25 @@ app = "http://registry.gpii.net/applications/org.chrome.cloud4chrome"
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "screenReaderBrailleOutput": false
   "screenReaderTTSEnabled": true
-  "speechRate": 99
-  "punctuationVerbosity": "all"
-  "announceCapitals": true
+  "speechRate": 247.5
+  "punctuationVerbosity": "some"
+  "announceCapitals": false
   ; keyEcho and wordEcho
-  "keyEcho": true
+  "keyEcho": false
   "wordEcho": true
-  _disabled=true
 
 
 ; Mobile Accessibility for Android (CodeFactory)
 [preferences]
 app = "http://registry.gpii.net/applications/es.codefactory.android.app.ma"
-  "access_commonprefs_speechrate": 4.03
+  "access_commonprefs_speechrate": 9.75
   ; punctuationVerbosity
-  "access_commonprefs_punctuation": "all"
+  "access_commonprefs_punctuation": "some"
   ; announceCapitals
-  "access_commonprefs_capitalization": true
+  "access_commonprefs_capitalization": false
   ; keyEcho and wordEcho (0 = none; 1 = characters; 2 = words; 3 = characters and words)
-  "access_commonprefs_editingkeyboardecho": 3
+  "access_commonprefs_editingkeyboardecho": 2
   ; pitch * 10 (MAA default : 5)
   "access_commonprefs_speechpitch": 4
-  _disabled=true
 
-
-; Android with TalkBack (FVE)
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.freespeech"
-  ; just start freespeech
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.talkback"
-  ; just start talkback
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.persistentConfiguration"
-  ; language (no mapping to auditoryOutLanguage; TTS lang is determined by the locale: http://issues.gpii.net/browse/GPII-456)
-  "locale": "fr"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.audioManager"
-  ; volumeTTS * 15
-  "STREAM_MUSIC": 5.25
-
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.system"
-
-[preferences]
-app = "http://registry.gpii.net/applications/com.android.settings.secure"
-  ; @@relationship to WPM not well established!!
-  "tts_default_rate": 160
-  ; pitch * 500 (Android default: 100)
-  "tts_default_pitch": 200
 

--- a/manualDataThirdPhase/screenreader_400_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_400_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_400_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 400
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 17
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_417_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_417_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_417_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 417
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 19
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_420_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_420_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_420_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 420
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 19
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_426_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_426_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_426_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 426
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 20
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_435_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_435_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_435_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 435
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 21
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_444_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_444_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_444_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 444
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 22
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_474_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_474_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_474_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 474
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 25
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_492_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_492_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_492_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 492
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 27
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_501_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_501_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_501_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 501
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 28
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_510_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_510_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_510_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 510
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 29
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_519_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_519_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_519_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 519
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 30
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_585_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_585_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_585_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 585
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 37
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_612_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_612_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_612_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 612
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 40
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_705_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_705_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_705_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 705
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 50
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+

--- a/manualDataThirdPhase/screenreader_984_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_984_rateboost.ini
@@ -1,0 +1,62 @@
+; screen reader settings on Windows, Linux
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_984_rateboost"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 984
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille.display": "noBraille"
+  ; screenReaderTTSEnabled
+  "speech.synth": "espeak"
+  "speech.outputDevice": "Microsoft Sound Mapper"
+  "speech.espeak.rate": 80
+  "speech.espeak.rateBoost": true
+  ; auditoryOutLanguage
+  "speech.espeak.voice": "en\\en"
+  ; trackingTTS
+  "reviewCursor.followFocus": True
+  "reviewCursor.followCaret": True
+  "reviewCursor.followMouse": True
+  ; punctuationVerbosity (default: some = 100)
+  "speech.symbolLevel": 200
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers.autoSayAllOnPageLoad": True
+  ; announceCapitals
+  "speech.espeak.sayCapForCapitals": True
+  ; keyEcho and wordEcho
+  "keyboard.speakTypedCharacters": True
+  "keyboard.speakTypedWords": True
+  ; volumeTTS * 100
+  "speech.espeak.volume": 70
+  ; pitch * 100 (NVDA default = 40)
+  "speech.espeak.pitch": 50
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.orca"
+  "enableBraille": false
+  "enableSpeech": true
+  ; Orca's maximum rate = 100
+  "voices.default.rate": 100
+  ; auditoryOutLanguage
+  "voices.default.family.locale": "en"
+  "voices.default.family.name": "english"
+  ; punctuationVerbosity (some = 2)
+  "verbalizePunctuationStyle": 1
+  ; "display.textReadingHighlight.readingUnit": 1 = sentence; 0 = line
+  "sayAllStyle": 1
+  ; announceCapitals: not supported
+  ; keyEcho and wordEcho
+  "enableEchoByCharacter": true
+  "enableEchoByWord": true
+  ; volumeTTS * 10
+  "voices.default.gain": 7
+  ; pitch * 10 (Orca default: 5.0)
+  "voices.default.average-pitch": 5.0
+


### PR DESCRIPTION
Training data for speech rates of 160 words per minute or higher, for Windows (NVDA, SuperNova), Linux (Orca), WebAnywhere, Android TalkBack and Mobile Accessibility for Android. 
