### PR TITLE
GPII-1112: NVDA True/False -> true false 

### DIFF
--- a/manualDataThirdPhase/screenreader_080.ini
+++ b/manualDataThirdPhase/screenreader_080.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "en\\en-wi"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= True
+  "speech\\.espeak\\.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= True
-  "keyboard\\.speakTypedWords"= False
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 25
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_080_tooltips.ini
+++ b/manualDataThirdPhase/screenreader_080_tooltips.ini
@@ -18,24 +18,24 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "en\\en-wi"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= True
+  "speech\\.espeak\\.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= True
-  "keyboard\\.speakTypedWords"= False
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 55
   ; pitch * 100 (NVDA default = 40)
   "speech\\.espeak\\.pitch"= 60
   ; speakToolTips
-  "presentation\\.reportTooltips"= False
+  "presentation\\.reportTooltips"=false
 
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_080_tutorialmessages.ini
+++ b/manualDataThirdPhase/screenreader_080_tutorialmessages.ini
@@ -20,24 +20,24 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "en\\en-wi"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= True
+  "speech\\.espeak\\.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= True
-  "keyboard\\.speakTypedWords"= False
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 40
   ; pitch * 100 (NVDA default = 40)
   "speech\\.espeak\\.pitch"= 70
   ; speakTutorialMessages
-  "presentation\\.reportHelpBalloons"= False
+  "presentation\\.reportHelpBalloons"=false
 
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_090.ini
+++ b/manualDataThirdPhase/screenreader_090.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "de"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= True
+  "speech\\.espeak\\.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= False
-  "keyboard\\.speakTypedWords"= True
+  "keyboard\\.speakTypedCharacters"=false
+  "keyboard\\.speakTypedWords"=true
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 10
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_090_tooltips.ini
+++ b/manualDataThirdPhase/screenreader_090_tooltips.ini
@@ -17,24 +17,24 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "de"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= True
+  "speech\\.espeak\\.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= False
-  "keyboard\\.speakTypedWords"= True
+  "keyboard\\.speakTypedCharacters"=false
+  "keyboard\\.speakTypedWords"=true
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 25
   ; pitch * 100 (NVDA default = 40)
   "speech\\.espeak\\.pitch"= 100
   ; speakToolTips
-  "presentation\\.reportTooltips"= True
+  "presentation\\.reportTooltips"=true
 
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_090_tutorialmessages.ini
+++ b/manualDataThirdPhase/screenreader_090_tutorialmessages.ini
@@ -19,24 +19,24 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "de"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= True
+  "speech\\.espeak\\.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= False
-  "keyboard\\.speakTypedWords"= True
+  "keyboard\\.speakTypedCharacters"=false
+  "keyboard\\.speakTypedWords"=true
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 10
   ; pitch * 100 (NVDA default = 40)
   "speech\\.espeak\\.pitch"= 10
   ; speakTutorialMessages
-  "presentation\\.reportHelpBalloons"= False
+  "presentation\\.reportHelpBalloons"=false
 
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_100.ini
+++ b/manualDataThirdPhase/screenreader_100.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "de"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 300
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= True
+  "speech\\.espeak\\.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= True
-  "keyboard\\.speakTypedWords"= True
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=true
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 95
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_100_tooltips.ini
+++ b/manualDataThirdPhase/screenreader_100_tooltips.ini
@@ -17,24 +17,24 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "de"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 300
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= True
+  "speech\\.espeak\\.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= True
-  "keyboard\\.speakTypedWords"= True
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=true
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 95
   ; pitch * 100 (NVDA default = 40)
   "speech\\.espeak\\.pitch"= 30
   ; speakToolTips
-  "presentation\\.reportTooltips"= False
+  "presentation\\.reportTooltips"=false
 
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_100_tutorialmessages.ini
+++ b/manualDataThirdPhase/screenreader_100_tutorialmessages.ini
@@ -20,24 +20,24 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "de"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 300
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= True
+  "speech\\.espeak\\.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= True
-  "keyboard\\.speakTypedWords"= True
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=true
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 80
   ; pitch * 100 (NVDA default = 40)
   "speech\\.espeak\\.pitch"= 40
   ; speakTutorialMessages
-  "presentation\\.reportHelpBalloons"= True
+  "presentation\\.reportHelpBalloons"=true
 
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_120.ini
+++ b/manualDataThirdPhase/screenreader_120.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "el"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= False
+  "speech\\.espeak\\.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= False
-  "keyboard\\.speakTypedWords"= False
+  "keyboard\\.speakTypedCharacters"=false
+  "keyboard\\.speakTypedWords"=false
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 80
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_120_tooltips.ini
+++ b/manualDataThirdPhase/screenreader_120_tooltips.ini
@@ -17,24 +17,24 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "el"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= False
+  "speech\\.espeak\\.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= False
-  "keyboard\\.speakTypedWords"= False
+  "keyboard\\.speakTypedCharacters"=false
+  "keyboard\\.speakTypedWords"=false
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 65
   ; pitch * 100 (NVDA default = 40)
   "speech\\.espeak\\.pitch"= 60
   ; speakToolTips
-  "presentation\\.reportTooltips"= True
+  "presentation\\.reportTooltips"=true
 
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_120_tutorialmessages.ini
+++ b/manualDataThirdPhase/screenreader_120_tutorialmessages.ini
@@ -20,24 +20,24 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "el"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= False
+  "speech\\.espeak\\.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= False
-  "keyboard\\.speakTypedWords"= False
+  "keyboard\\.speakTypedCharacters"=false
+  "keyboard\\.speakTypedWords"=false
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 50
   ; pitch * 100 (NVDA default = 40)
   "speech\\.espeak\\.pitch"= 70
   ; speakTutorialMessages
-  "presentation\\.reportHelpBalloons"= True
+  "presentation\\.reportHelpBalloons"=true
 
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_135.ini
+++ b/manualDataThirdPhase/screenreader_135.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "es"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 100
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= False
+  "speech\\.espeak\\.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= True
-  "keyboard\\.speakTypedWords"= False
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 65
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_135_tooltips.ini
+++ b/manualDataThirdPhase/screenreader_135_tooltips.ini
@@ -17,24 +17,24 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "es"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 100
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= False
+  "speech\\.espeak\\.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= True
-  "keyboard\\.speakTypedWords"= False
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 35
   ; pitch * 100 (NVDA default = 40)
   "speech\\.espeak\\.pitch"= 90
   ; speakToolTips
-  "presentation\\.reportTooltips"= False
+  "presentation\\.reportTooltips"=false
 
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_135_tutorialmessages.ini
+++ b/manualDataThirdPhase/screenreader_135_tutorialmessages.ini
@@ -20,24 +20,24 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "es"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 100
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= False
+  "speech\\.espeak\\.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= True
-  "keyboard\\.speakTypedWords"= False
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 20
   ; pitch * 100 (NVDA default = 40)
   "speech\\.espeak\\.pitch"= 100
   ; speakTutorialMessages
-  "presentation\\.reportHelpBalloons"= False
+  "presentation\\.reportHelpBalloons"=false
 
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_150.ini
+++ b/manualDataThirdPhase/screenreader_150.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech\\.espeak\\.voice"= "es"
   ; trackingTTS
-  "reviewCursor\\.followFocus"= True
-  "reviewCursor\\.followCaret"= True
-  "reviewCursor\\.followMouse"= True
+  "reviewCursor\\.followFocus"=true
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech\\.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers\\.autoSayAllOnPageLoad"= True
+  "virtualBuffers\\.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech\\.espeak\\.sayCapForCapitals"= False
+  "speech\\.espeak\\.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard\\.speakTypedCharacters"= False
-  "keyboard\\.speakTypedWords"= True
+  "keyboard\\.speakTypedCharacters"=false
+  "keyboard\\.speakTypedWords"=true
   ; volumeTTS * 100
   "speech\\.espeak\\.volume"= 50
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_160.ini
+++ b/manualDataThirdPhase/screenreader_160.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "fr"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 300
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 35
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_160_m11y.ini
+++ b/manualDataThirdPhase/screenreader_160_m11y.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "fr"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 300
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 35
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_173.ini
+++ b/manualDataThirdPhase/screenreader_173.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "it"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= False
-  "keyboard.speakTypedWords"= False
+  "keyboard.speakTypedCharacters"=false
+  "keyboard.speakTypedWords"=false
   ; volumeTTS * 100
   "speech.espeak.volume"= 20
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_173_m11y.ini
+++ b/manualDataThirdPhase/screenreader_173_m11y.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "it"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= False
-  "keyboard.speakTypedWords"= False
+  "keyboard.speakTypedCharacters"=false
+  "keyboard.speakTypedWords"=false
   ; volumeTTS * 100
   "speech.espeak.volume"= 20
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_184.ini
+++ b/manualDataThirdPhase/screenreader_184.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "nl"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 100
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= False
+  "speech.espeak.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= False
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=false
   ; volumeTTS * 100
   "speech.espeak.volume"= 5
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_184_m11y.ini
+++ b/manualDataThirdPhase/screenreader_184_m11y.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "nl"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 100
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= False
+  "speech.espeak.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= False
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=false
   ; volumeTTS * 100
   "speech.espeak.volume"= 5
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_200.ini
+++ b/manualDataThirdPhase/screenreader_200.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "zh"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= False
+  "speech.espeak.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= False
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=false
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 90
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_200_m11y.ini
+++ b/manualDataThirdPhase/screenreader_200_m11y.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "zh"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= False
+  "speech.espeak.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= False
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=false
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 90
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_220.ini
+++ b/manualDataThirdPhase/screenreader_220.ini
@@ -15,18 +15,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 300
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= False
+  "speech.espeak.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 75
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_220_m11y.ini
+++ b/manualDataThirdPhase/screenreader_220_m11y.ini
@@ -15,18 +15,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 300
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= False
+  "speech.espeak.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 75
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_250.ini
+++ b/manualDataThirdPhase/screenreader_250.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= False
-  "keyboard.speakTypedWords"= False
+  "keyboard.speakTypedCharacters"=false
+  "keyboard.speakTypedWords"=false
   ; volumeTTS * 100
   "speech.espeak.volume"= 60
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_250_m11y.ini
+++ b/manualDataThirdPhase/screenreader_250_m11y.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= False
-  "keyboard.speakTypedWords"= False
+  "keyboard.speakTypedCharacters"=false
+  "keyboard.speakTypedWords"=false
   ; volumeTTS * 100
   "speech.espeak.volume"= 60
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_280.ini
+++ b/manualDataThirdPhase/screenreader_280.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en-us"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 100
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= False
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=false
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 45
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_280_m11y.ini
+++ b/manualDataThirdPhase/screenreader_280_m11y.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en-us"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 100
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= False
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=false
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 45
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_310.ini
+++ b/manualDataThirdPhase/screenreader_310.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "de"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 30
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_310_m11y.ini
+++ b/manualDataThirdPhase/screenreader_310_m11y.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "de"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 30
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_320.ini
+++ b/manualDataThirdPhase/screenreader_320.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "de"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 300
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= False
+  "speech.espeak.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= False
-  "keyboard.speakTypedWords"= False
+  "keyboard.speakTypedCharacters"=false
+  "keyboard.speakTypedWords"=false
   ; volumeTTS * 100
   "speech.espeak.volume"= 15
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_320_m11y.ini
+++ b/manualDataThirdPhase/screenreader_320_m11y.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "de"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 300
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= False
+  "speech.espeak.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= False
-  "keyboard.speakTypedWords"= False
+  "keyboard.speakTypedCharacters"=false
+  "keyboard.speakTypedWords"=false
   ; volumeTTS * 100
   "speech.espeak.volume"= 15
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_360.ini
+++ b/manualDataThirdPhase/screenreader_360.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "el"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= False
+  "speech.espeak.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= False
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=false
   ; volumeTTS * 100
   "speech.espeak.volume"= 100
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_360_m11y.ini
+++ b/manualDataThirdPhase/screenreader_360_m11y.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "el"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 0
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= False
+  "speech.espeak.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= False
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=false
   ; volumeTTS * 100
   "speech.espeak.volume"= 100
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_390.ini
+++ b/manualDataThirdPhase/screenreader_390.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "es"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 100
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= False
+  "speech.espeak.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= False
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=false
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 85
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_390_m11y.ini
+++ b/manualDataThirdPhase/screenreader_390_m11y.ini
@@ -19,18 +19,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "es"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 100
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= False
+  "speech.espeak.sayCapForCapitals"=false
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= False
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=false
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 85
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_400_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_400_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_417_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_417_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_420_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_420_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_426_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_426_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_435_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_435_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_444_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_444_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_474_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_474_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_492_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_492_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_501_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_501_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_510_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_510_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_519_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_519_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_585_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_585_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_612_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_612_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_705_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_705_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)

--- a/manualDataThirdPhase/screenreader_984_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_984_rateboost.ini
@@ -20,18 +20,18 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   ; auditoryOutLanguage
   "speech.espeak.voice"= "en\\en"
   ; trackingTTS
-  "reviewCursor.followFocus"= True
-  "reviewCursor.followCaret"= True
-  "reviewCursor.followMouse"= True
+  "reviewCursor.followFocus"=true
+  "reviewCursor.followCaret"=true
+  "reviewCursor.followMouse"=true
   ; punctuationVerbosity (default: some = 100)
   "speech.symbolLevel"= 200
   ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
-  "virtualBuffers.autoSayAllOnPageLoad"= True
+  "virtualBuffers.autoSayAllOnPageLoad"=true
   ; announceCapitals
-  "speech.espeak.sayCapForCapitals"= True
+  "speech.espeak.sayCapForCapitals"=true
   ; keyEcho and wordEcho
-  "keyboard.speakTypedCharacters"= True
-  "keyboard.speakTypedWords"= True
+  "keyboard.speakTypedCharacters"=true
+  "keyboard.speakTypedWords"=true
   ; volumeTTS * 100
   "speech.espeak.volume"= 70
   ; pitch * 100 (NVDA default = 40)


### PR DESCRIPTION
In NVDA's configuration file nvda.ini (see the example at http://wiki.gpii.net/w/Screen_Reader_Settings:_NVDA), Boolean values are always written as True and False, but GPII NP sets need them to be written as true and false, otherwise they might be interpreted as strings (and thus quoted) at some point in the process.
