### PR TITLE
GPII-1112: disable mouse trails SuperNova mag

### DIFF
--- a/manualDataThirdPhase/win7_magnifier_1-1_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-1_sn.ini
@@ -24,6 +24,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.2
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 1.1

--- a/manualDataThirdPhase/win7_magnifier_1-1_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-1_sn.ini
@@ -24,10 +24,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.2
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_1-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-2_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.2
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_1-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-2_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.2
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 1.2

--- a/manualDataThirdPhase/win7_magnifier_1-3_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-3_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.3
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_1-3_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-3_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.3
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 1.3

--- a/manualDataThirdPhase/win7_magnifier_1-4_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-4_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.4
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_1-4_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-4_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.4
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 1.4

--- a/manualDataThirdPhase/win7_magnifier_1-5_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-5_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.5
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 1.5

--- a/manualDataThirdPhase/win7_magnifier_1-5_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-5_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.5
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_1-6_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-6_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.6
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_1-6_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-6_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.6
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 1.6

--- a/manualDataThirdPhase/win7_magnifier_1-7_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-7_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.7
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 1.7

--- a/manualDataThirdPhase/win7_magnifier_1-7_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-7_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.7
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_1-8_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-8_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.8
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_1-8_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-8_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.8
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 1.8

--- a/manualDataThirdPhase/win7_magnifier_1-9_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-9_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.9
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 1.9

--- a/manualDataThirdPhase/win7_magnifier_1-9_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_1-9_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 1.9
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_16-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_16-0_sn.ini
@@ -24,10 +24,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 16.0
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_16-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_16-0_sn.ini
@@ -24,6 +24,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 16.0
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 16.0

--- a/manualDataThirdPhase/win7_magnifier_2-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-0_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 2.0
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_2-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-0_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 2.0
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 2.0

--- a/manualDataThirdPhase/win7_magnifier_2-1_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-1_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 2.1
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 2.1

--- a/manualDataThirdPhase/win7_magnifier_2-1_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-1_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 2.1
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_2-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-2_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 2.2
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 2.2

--- a/manualDataThirdPhase/win7_magnifier_2-2_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-2_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 2.2
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_2-3_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-3_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 2.3
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 2.3

--- a/manualDataThirdPhase/win7_magnifier_2-3_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-3_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 2.3
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_2-4_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-4_sn.ini
@@ -23,6 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 2.4
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 2.4

--- a/manualDataThirdPhase/win7_magnifier_2-4_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_2-4_sn.ini
@@ -23,10 +23,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 2.4
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_24-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_24-0_sn.ini
@@ -24,10 +24,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 24.0
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_24-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_24-0_sn.ini
@@ -24,6 +24,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 24.0
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   "mag-factor"= 24.0

--- a/manualDataThirdPhase/win7_magnifier_32-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_32-0_sn.ini
@@ -24,10 +24,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 32.0
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_32-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_32-0_sn.ini
@@ -24,6 +24,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 32.0
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   ; 32.0 is the upper limit for the Gnome Magnifier

--- a/manualDataThirdPhase/win7_magnifier_48-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_48-0_sn.ini
@@ -24,10 +24,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 48.0
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"

--- a/manualDataThirdPhase/win7_magnifier_48-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_48-0_sn.ini
@@ -24,6 +24,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 48.0
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   ; 32.0 is the upper limit for the Gnome Magnifier

--- a/manualDataThirdPhase/win7_magnifier_60-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_60-0_sn.ini
@@ -25,6 +25,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 60.0
   "magnifierPosition"= "FullScreen"
 
+; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
+  MouseTrails= 0
+
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   ; 32.0 is the upper limit for the Gnome Magnifier

--- a/manualDataThirdPhase/win7_magnifier_60-0_sn.ini
+++ b/manualDataThirdPhase/win7_magnifier_60-0_sn.ini
@@ -25,10 +25,11 @@ app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
   "magnification"= 60.0
   "magnifierPosition"= "FullScreen"
 
-; disable mouse trails when running SuperNova: https://twitter.com/yourdolphin/status/601697014011797505
+; disable mouse trails when running SuperNova: http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612 & https://twitter.com/yourdolphin/status/601697014011797505
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.mouseTrailing"
   MouseTrails= 0
+  _disabled=true
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"


### PR DESCRIPTION
Turn off Windows' pointer trails in order to avoid the appearance of two pointers on the screen. See Dolphin's knowledge base article at http://www.yourdolphin.com/knowledgebase.asp?act=display&pg=&ksearch=&id=612.
