### PR TITLE
GPII-1112: TTS language in Sociable and screen readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ The key-value pairs use terms that are either in the namespace
 or in an application-specific namespace, e.g. 
 `http://registry.gpii.net/applications/net.opendirective.maavis`.
 
-The only exception to this rule is the term **`_disabled`** (with the values 
-`true`, `false` or `unknown`; default value is `false`). 
+The only exception to this rule is the term **`_disabled`**,
+which was introduced in the training data for the third pilot phase
+(with the values `true`, `false` or `unknown`; default value is `false`). 
 
 When set to `true`, this term signals to the Statistical Matchmaker that the
 solution it applies to should not be launched. The goal is to prevent 

--- a/manualDataThirdPhase/_language_de.ini
+++ b/manualDataThirdPhase/_language_de.ini
@@ -34,10 +34,10 @@ app = "http://registry.gpii.net/applications/net.gpii.smarthouse"
   _disabled=unknown
   language = "de"
 
-[preferences]
-app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
-  _disabled=unknown
-  language = "de"
+;[preferences]
+;app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
+;  _disabled=unknown
+;  language = "de"
 
 [preferences]
 app = "http://registry.gpii.net/applications/de.fraunhofer.iao.C4A-TVM"

--- a/manualDataThirdPhase/_language_es-419.ini
+++ b/manualDataThirdPhase/_language_es-419.ini
@@ -34,10 +34,10 @@ app = "http://registry.gpii.net/applications/net.gpii.smarthouse"
   _disabled=unknown
   language = "es"
 
-[preferences]
-app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
-  _disabled=unknown
-  language = "es"
+;[preferences]
+;app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
+;  _disabled=unknown
+;  language = "es"
 
 [preferences]
 app = "http://registry.gpii.net/applications/de.fraunhofer.iao.C4A-TVM"

--- a/manualDataThirdPhase/_language_es-ES.ini
+++ b/manualDataThirdPhase/_language_es-ES.ini
@@ -34,10 +34,10 @@ app = "http://registry.gpii.net/applications/net.gpii.smarthouse"
   _disabled=unknown
   language = "es"
 
-[preferences]
-app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
-  _disabled=unknown
-  language = "es"
+;[preferences]
+;app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
+;  _disabled=unknown
+;  language = "es"
 
 [preferences]
 app = "http://registry.gpii.net/applications/de.fraunhofer.iao.C4A-TVM"

--- a/manualDataThirdPhase/_language_es.ini
+++ b/manualDataThirdPhase/_language_es.ini
@@ -34,10 +34,10 @@ app = "http://registry.gpii.net/applications/net.gpii.smarthouse"
   _disabled=unknown
   language = "es"
 
-[preferences]
-app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
-  _disabled=unknown
-  language = "es"
+;[preferences]
+;app = "http://registry.gpii.net/applications/eu.singularlogic.pixelsense.sociable"
+;  _disabled=unknown
+;  language = "es"
 
 [preferences]
 app = "http://registry.gpii.net/applications/de.fraunhofer.iao.C4A-TVM"

--- a/manualDataThirdPhase/screenreader_080.ini
+++ b/manualDataThirdPhase/screenreader_080.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 80
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
@@ -17,7 +18,7 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
   "speech\\.outputDevice"= "Microsoft Sound Mapper"
   "speech\\.espeak\\.rate"= 0
   ; auditoryOutLanguage
-  "speech\\.espeak\\.voice"= "en\\en-wi"
+  "speech\\.espeak\\.voice"= "en\\en"
   ; trackingTTS
   "reviewCursor\\.followFocus"=true
   "reviewCursor\\.followCaret"=true

--- a/manualDataThirdPhase/screenreader_080_tooltips.ini
+++ b/manualDataThirdPhase/screenreader_080_tooltips.ini
@@ -6,6 +6,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 80
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_080_tutorialmessages.ini
+++ b/manualDataThirdPhase/screenreader_080_tutorialmessages.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 80
+  auditoryOutLanguage = "en"
   speakTutorialMessages = false
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_090.ini
+++ b/manualDataThirdPhase/screenreader_090.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 90
+  auditoryOutLanguage = "de"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_090_tooltips.ini
+++ b/manualDataThirdPhase/screenreader_090_tooltips.ini
@@ -5,6 +5,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 90
+  auditoryOutLanguage = "de"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_090_tutorialmessages.ini
+++ b/manualDataThirdPhase/screenreader_090_tutorialmessages.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 90
+  auditoryOutLanguage = "de"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_100.ini
+++ b/manualDataThirdPhase/screenreader_100.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 100
+  auditoryOutLanguage = "de"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_100_tooltips.ini
+++ b/manualDataThirdPhase/screenreader_100_tooltips.ini
@@ -5,6 +5,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 100
+  auditoryOutLanguage = "de"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_100_tutorialmessages.ini
+++ b/manualDataThirdPhase/screenreader_100_tutorialmessages.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 100
+  auditoryOutLanguage = "de"
   speakTutorialMessages = true
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_120.ini
+++ b/manualDataThirdPhase/screenreader_120.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 120
+  auditoryOutLanguage = "el"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_120_tooltips.ini
+++ b/manualDataThirdPhase/screenreader_120_tooltips.ini
@@ -5,6 +5,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 120
+  auditoryOutLanguage = "el"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_120_tutorialmessages.ini
+++ b/manualDataThirdPhase/screenreader_120_tutorialmessages.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 120
+  auditoryOutLanguage = "el"
   speakTutorialMessages = true
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_135.ini
+++ b/manualDataThirdPhase/screenreader_135.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 135
+  auditoryOutLanguage = "es"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_135_tooltips.ini
+++ b/manualDataThirdPhase/screenreader_135_tooltips.ini
@@ -5,6 +5,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 135
+  auditoryOutLanguage = "es"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_135_tutorialmessages.ini
+++ b/manualDataThirdPhase/screenreader_135_tutorialmessages.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 135
+  auditoryOutLanguage = "es"
   speakTutorialMessages = false
 
 [preferences]

--- a/manualDataThirdPhase/screenreader_150.ini
+++ b/manualDataThirdPhase/screenreader_150.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 150
+  auditoryOutLanguage = "es"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_160.ini
+++ b/manualDataThirdPhase/screenreader_160.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 160
+  auditoryOutLanguage = "fr"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_160_m11y.ini
+++ b/manualDataThirdPhase/screenreader_160_m11y.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 160
+  auditoryOutLanguage = "fr"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_173.ini
+++ b/manualDataThirdPhase/screenreader_173.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 173
+  auditoryOutLanguage = "it"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_173_m11y.ini
+++ b/manualDataThirdPhase/screenreader_173_m11y.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 173
+  auditoryOutLanguage = "it"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_184.ini
+++ b/manualDataThirdPhase/screenreader_184.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 184
+  auditoryOutLanguage = "nl"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_184_m11y.ini
+++ b/manualDataThirdPhase/screenreader_184_m11y.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 184
+  auditoryOutLanguage = "nl"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_200.ini
+++ b/manualDataThirdPhase/screenreader_200.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 200
+  auditoryOutLanguage = "zh"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_200_m11y.ini
+++ b/manualDataThirdPhase/screenreader_200_m11y.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 200
+  auditoryOutLanguage = "zh"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_220.ini
+++ b/manualDataThirdPhase/screenreader_220.ini
@@ -5,6 +5,11 @@ user = "screenreader_220"
 os = "windows"
 
 [preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 220
+  auditoryOutLanguage = "en"
+
+[preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
   ; screenReaderBrailleOutput (default = "noBraille")
   "braille.display"= "noBraille"

--- a/manualDataThirdPhase/screenreader_220_m11y.ini
+++ b/manualDataThirdPhase/screenreader_220_m11y.ini
@@ -5,6 +5,11 @@ user = "screenreader_220_m11y"
 os = "windows"
 
 [preferences]
+app = "http://registry.gpii.net/common"
+  speechRate = 220
+  auditoryOutLanguage = "en"
+
+[preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"
   ; screenReaderBrailleOutput (default = "noBraille")
   "braille.display"= "noBraille"

--- a/manualDataThirdPhase/screenreader_250.ini
+++ b/manualDataThirdPhase/screenreader_250.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 250
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_250_m11y.ini
+++ b/manualDataThirdPhase/screenreader_250_m11y.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 250
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_280.ini
+++ b/manualDataThirdPhase/screenreader_280.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 280
+  auditoryOutLanguage = "en-US"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_280_m11y.ini
+++ b/manualDataThirdPhase/screenreader_280_m11y.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 280
+  auditoryOutLanguage = "en-US"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_310.ini
+++ b/manualDataThirdPhase/screenreader_310.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 310
+  auditoryOutLanguage = "de"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_310_m11y.ini
+++ b/manualDataThirdPhase/screenreader_310_m11y.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 310
+  auditoryOutLanguage = "de"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_320.ini
+++ b/manualDataThirdPhase/screenreader_320.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 320
+  auditoryOutLanguage = "de"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_320_m11y.ini
+++ b/manualDataThirdPhase/screenreader_320_m11y.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 320
+  auditoryOutLanguage = "de"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_360.ini
+++ b/manualDataThirdPhase/screenreader_360.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 360
+  auditoryOutLanguage = "el"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_360_m11y.ini
+++ b/manualDataThirdPhase/screenreader_360_m11y.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 360
+  auditoryOutLanguage = "el"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_390.ini
+++ b/manualDataThirdPhase/screenreader_390.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 390
+  auditoryOutLanguage = "es"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_390_m11y.ini
+++ b/manualDataThirdPhase/screenreader_390_m11y.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 390
+  auditoryOutLanguage = "es"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_400_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_400_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 400
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_417_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_417_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 417
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_420_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_420_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 420
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_426_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_426_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 426
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_435_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_435_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 435
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_444_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_444_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 444
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_474_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_474_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 474
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_492_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_492_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 492
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_501_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_501_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 501
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_510_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_510_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 510
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_519_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_519_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 519
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_585_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_585_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 585
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_612_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_612_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 612
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_705_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_705_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 705
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/screenreader_984_rateboost.ini
+++ b/manualDataThirdPhase/screenreader_984_rateboost.ini
@@ -7,6 +7,7 @@ os = "windows"
 [preferences]
 app = "http://registry.gpii.net/common"
   speechRate = 984
+  auditoryOutLanguage = "en"
 
 [preferences]
 app = "http://registry.gpii.net/applications/org.nvda-project"

--- a/manualDataThirdPhase/win7_highcontrast_01.ini
+++ b/manualDataThirdPhase/win7_highcontrast_01.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
 
 [preferences]
 app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  _disabled=true
   ; fontSize is in pixels
   "fontSize"= 18
   "highContrastTheme"= "black-white"

--- a/manualDataThirdPhase/win7_highcontrast_11.ini
+++ b/manualDataThirdPhase/win7_highcontrast_11.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
 
 [preferences]
 app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  _disabled=true
   ; fontSize is in pixels
   "fontSize"= 18
   "highContrastTheme"= "white-black"

--- a/manualDataThirdPhase/win7_highcontrast_21.ini
+++ b/manualDataThirdPhase/win7_highcontrast_21.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
 
 [preferences]
 app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  _disabled=true
   ; fontSize is in pixels
   "fontSize"= 18
   "highContrastTheme"= "yellow-black"

--- a/manualDataThirdPhase/win7_highcontrast_31.ini
+++ b/manualDataThirdPhase/win7_highcontrast_31.ini
@@ -21,6 +21,7 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
 
 [preferences]
 app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  _disabled=true
   ; fontSize is in pixels
   "fontSize"= 18
   "highContrastTheme"= "black-yellow"

--- a/manualDataThirdPhase/win7_normalcontrast_01.ini
+++ b/manualDataThirdPhase/win7_normalcontrast_01.ini
@@ -17,6 +17,7 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
 
 [preferences]
 app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  _disabled=true
 	; fontSize is in pixels
 	fontSize = 18
 	; highContrastTheme = "black-white"

--- a/manualDataThirdPhase/win7_normalcontrast_01_de.ini
+++ b/manualDataThirdPhase/win7_normalcontrast_01_de.ini
@@ -17,6 +17,7 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
 
 [preferences]
 app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  _disabled=true
 	; fontSize is in pixels
 	fontSize = 18
 	; highContrastTheme = "black-white"

--- a/manualDataThirdPhase/win7_normalcontrast_01_el.ini
+++ b/manualDataThirdPhase/win7_normalcontrast_01_el.ini
@@ -17,6 +17,7 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
 
 [preferences]
 app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  _disabled=true
 	; fontSize is in pixels
 	fontSize = 18
 	; highContrastTheme = "black-white"

--- a/manualDataThirdPhase/win7_normalcontrast_01_en-GB.ini
+++ b/manualDataThirdPhase/win7_normalcontrast_01_en-GB.ini
@@ -17,6 +17,7 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
 
 [preferences]
 app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  _disabled=true
 	; fontSize is in pixels
 	fontSize = 18
 	; highContrastTheme = "black-white"

--- a/manualDataThirdPhase/win7_normalcontrast_01_es.ini
+++ b/manualDataThirdPhase/win7_normalcontrast_01_es.ini
@@ -17,6 +17,7 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
 
 [preferences]
 app = "http://registry.gpii.net/applications/net.gpii.smarthouses"
+  _disabled=true
 	; fontSize is in pixels
 	fontSize = 18
 	; highContrastTheme = "black-white"


### PR DESCRIPTION
- Sociable is only available in English and Greek, so the solution was removed from NP sets that use Spanish or German.
- Two NP sets for screen readers had no common terms; common terms for speechRate and auditoryOutLanguage has been added.
- Most NP sets for screen readers had only one common terms (speechRate); auditoryOutLanguage has been added.
