### PR TITLE
GPII-1112: training data for use cases 1a, 1b, 1c, 1d, 2 and 3

### DIFF
--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_de.ini
@@ -32,7 +32,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   Language = "German"
   ; @@Pitch range = 1 .. 100??
   Pitch = 80
-  ; "OSM\\.TrackFocusRect" = false
+  ; "OSM\\.TrackFocusRect" = 0
 
 
 [preferences]

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_de.ini
@@ -1,0 +1,78 @@
+; screen reader settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1a_300_de"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = false
+  punctuationVerbosity = "some"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "de"
+  pitch = 0.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 25
+  "OSM\\.UseVirtualPCCursor" = true
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  ; "Options\\.SayAllIndicateCaps" is not in DEFAULT.JCF when it is disabled.
+  Punctuation = 1
+  "Options\\.SayAllMode" = 2
+  Language = "German"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 71
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "de"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=false
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  punctuationVerbosity= "some"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_de.ini
@@ -22,7 +22,7 @@ app = "http://registry.gpii.net/common"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   ; @@JAWS settings files have no setting to disable TTS??
   Speed = 25
-  "OSM\\.UseVirtualPCCursor" = true
+  "OSM\\.UseVirtualPCCursor" = 1
   ; speakTutorialMessages not supported?
   ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
   ; "Options\\.TypingEcho" = 1 

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_el.ini
@@ -23,7 +23,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   _disabled=true
   ; @@JAWS settings files have no setting to disable TTS??
   Speed = 25
-  "OSM\\.UseVirtualPCCursor" = true
+  "OSM\\.UseVirtualPCCursor" = 1
   ; speakTutorialMessages not supported?
   ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
   ; "Options\\.TypingEcho" = 1 

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_el.ini
@@ -1,0 +1,79 @@
+; screen reader settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1a_300_el"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = false
+  punctuationVerbosity = "some"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "el"
+  pitch = 0.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  _disabled=true
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 25
+  "OSM\\.UseVirtualPCCursor" = true
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  ; "Options\\.SayAllIndicateCaps" is not in DEFAULT.JCF when it is disabled.
+  Punctuation = 1
+  "Options\\.SayAllMode" = 2
+  ; @@ Greek is not listed in the English version of JAWS 16??
+  Language = "Greek"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 71
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "el"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=false
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  punctuationVerbosity= "some"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_el.ini
@@ -34,7 +34,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   Language = "Greek"
   ; @@Pitch range = 1 .. 100??
   Pitch = 80
-  ; "OSM\\.TrackFocusRect" = false
+  ; "OSM\\.TrackFocusRect" = 0
 
 
 [preferences]

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_es.ini
@@ -32,7 +32,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   Language = "Castilian Spanish"
   ; @@Pitch range = 1 .. 100??
   Pitch = 80
-  ; "OSM\\.TrackFocusRect" = false
+  ; "OSM\\.TrackFocusRect" = 0
 
 
 [preferences]

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_es.ini
@@ -1,0 +1,78 @@
+; screen reader settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1a_300_es"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = false
+  punctuationVerbosity = "some"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "es"
+  pitch = 0.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 25
+  "OSM\\.UseVirtualPCCursor" = true
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  ; "Options\\.SayAllIndicateCaps" is not in DEFAULT.JCF when it is disabled.
+  Punctuation = 1
+  "Options\\.SayAllMode" = 2
+  Language = "Castilian Spanish"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 71
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "es"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=false
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  punctuationVerbosity= "some"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1a_300_es.ini
@@ -22,7 +22,7 @@ app = "http://registry.gpii.net/common"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   ; @@JAWS settings files have no setting to disable TTS??
   Speed = 25
-  "OSM\\.UseVirtualPCCursor" = true
+  "OSM\\.UseVirtualPCCursor" = 1
   ; speakTutorialMessages not supported?
   ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
   ; "Options\\.TypingEcho" = 1 

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_de.ini
@@ -32,7 +32,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   Language = "German"
   ; @@Pitch range = 1 .. 100??
   Pitch = 60
-  ; "OSM\\.TrackFocusRect" = false
+  ; "OSM\\.TrackFocusRect" = 0
 
 
 [preferences]

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_de.ini
@@ -22,7 +22,7 @@ app = "http://registry.gpii.net/common"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   ; @@JAWS settings files have no setting to disable TTS??
   Speed = 19
-  "OSM\\.UseVirtualPCCursor" = true
+  "OSM\\.UseVirtualPCCursor" = 1
   ; speakTutorialMessages not supported?
   ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
   ; "Options\\.TypingEcho" = 1 

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_de.ini
@@ -1,0 +1,78 @@
+; screen reader settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1b_250_de"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 250
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = false
+  punctuationVerbosity = "some"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "de"
+  pitch = 0.6
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 19
+  "OSM\\.UseVirtualPCCursor" = true
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  ; "Options\\.SayAllIndicateCaps" is not in DEFAULT.JCF when it is disabled.
+  Punctuation = 1
+  "Options\\.SayAllMode" = 2
+  Language = "German"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 60
+  ; "OSM\\.TrackFocusRect" = false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 55
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "de"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=false
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 60
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 250
+  punctuationVerbosity= "some"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_el.ini
@@ -23,7 +23,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   _disabled=true
   ; @@JAWS settings files have no setting to disable TTS??
   Speed = 19
-  "OSM\\.UseVirtualPCCursor" = true
+  "OSM\\.UseVirtualPCCursor" = 1
   ; speakTutorialMessages not supported?
   ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
   ; "Options\\.TypingEcho" = 1 

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_el.ini
@@ -1,0 +1,79 @@
+; screen reader settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1b_250_el"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 250
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = false
+  punctuationVerbosity = "some"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "el"
+  pitch = 0.6
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  _disabled=true
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 19
+  "OSM\\.UseVirtualPCCursor" = true
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  ; "Options\\.SayAllIndicateCaps" is not in DEFAULT.JCF when it is disabled.
+  Punctuation = 1
+  "Options\\.SayAllMode" = 2
+  ; @@ Greek is not listed in the English version of JAWS 16??
+  Language = "Greek"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 60
+  ; "OSM\\.TrackFocusRect" = false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 55
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "el"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=false
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 60
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 250
+  punctuationVerbosity= "some"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_el.ini
@@ -34,7 +34,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   Language = "Greek"
   ; @@Pitch range = 1 .. 100??
   Pitch = 60
-  ; "OSM\\.TrackFocusRect" = false
+  ; "OSM\\.TrackFocusRect" = 0
 
 
 [preferences]

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_es.ini
@@ -32,7 +32,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   Language = "Castilian Spanish"
   ; @@Pitch range = 1 .. 100??
   Pitch = 60
-  ; "OSM\\.TrackFocusRect" = false
+  ; "OSM\\.TrackFocusRect" = 0
 
 
 [preferences]

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_es.ini
@@ -1,0 +1,78 @@
+; screen reader settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1b_250_es"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 250
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = false
+  punctuationVerbosity = "some"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "es"
+  pitch = 0.6
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 19
+  "OSM\\.UseVirtualPCCursor" = true
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  ; "Options\\.SayAllIndicateCaps" is not in DEFAULT.JCF when it is disabled.
+  Punctuation = 1
+  "Options\\.SayAllMode" = 2
+  Language = "Castilian Spanish"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 60
+  ; "OSM\\.TrackFocusRect" = false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 55
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "es"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=false
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 60
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 250
+  punctuationVerbosity= "some"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1b_250_es.ini
@@ -22,7 +22,7 @@ app = "http://registry.gpii.net/common"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   ; @@JAWS settings files have no setting to disable TTS??
   Speed = 19
-  "OSM\\.UseVirtualPCCursor" = true
+  "OSM\\.UseVirtualPCCursor" = 1
   ; speakTutorialMessages not supported?
   ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
   ; "Options\\.TypingEcho" = 1 

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_de.ini
@@ -1,0 +1,78 @@
+; screen reader settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1c_280_de"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 280
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = true
+  punctuationVerbosity = "most"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "de"
+  pitch = 0.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 23
+  "OSM\\.UseVirtualPCCursor" = true
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  "Options\\.SayAllIndicateCaps" = 1
+  Punctuation = 2
+  "Options\\.SayAllMode" = 2
+  Language = "German"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 64
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "de"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=true
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 280
+  punctuationVerbosity= "most"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_de.ini
@@ -32,7 +32,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   Language = "German"
   ; @@Pitch range = 1 .. 100??
   Pitch = 80
-  ; "OSM\\.TrackFocusRect" = false
+  ; "OSM\\.TrackFocusRect" = 0
 
 
 [preferences]

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_de.ini
@@ -22,7 +22,7 @@ app = "http://registry.gpii.net/common"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   ; @@JAWS settings files have no setting to disable TTS??
   Speed = 23
-  "OSM\\.UseVirtualPCCursor" = true
+  "OSM\\.UseVirtualPCCursor" = 1
   ; speakTutorialMessages not supported?
   ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
   ; "Options\\.TypingEcho" = 1 

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_el.ini
@@ -33,7 +33,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   Language = "Greek"
   ; @@Pitch range = 1 .. 100??
   Pitch = 80
-  ; "OSM\\.TrackFocusRect" = false
+  ; "OSM\\.TrackFocusRect" = 0
 
 
 [preferences]

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_el.ini
@@ -22,7 +22,7 @@ app = "http://registry.gpii.net/common"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   ; @@JAWS settings files have no setting to disable TTS??
   Speed = 23
-  "OSM\\.UseVirtualPCCursor" = true
+  "OSM\\.UseVirtualPCCursor" = 1
   ; speakTutorialMessages not supported?
   ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
   ; "Options\\.TypingEcho" = 1 

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_el.ini
@@ -1,0 +1,79 @@
+; screen reader settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1c_280_el"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 280
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = true
+  punctuationVerbosity = "most"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "el"
+  pitch = 0.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 23
+  "OSM\\.UseVirtualPCCursor" = true
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  "Options\\.SayAllIndicateCaps" = 1
+  Punctuation = 2
+  "Options\\.SayAllMode" = 2
+  ; @@ Greek is not listed in the English version of JAWS 16??
+  Language = "Greek"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 64
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "el"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=true
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 280
+  punctuationVerbosity= "most"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_es.ini
@@ -32,7 +32,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   Language = "Castilian Spanish"
   ; @@Pitch range = 1 .. 100??
   Pitch = 80
-  ; "OSM\\.TrackFocusRect" = false
+  ; "OSM\\.TrackFocusRect" = 0
 
 
 [preferences]

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_es.ini
@@ -22,7 +22,7 @@ app = "http://registry.gpii.net/common"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   ; @@JAWS settings files have no setting to disable TTS??
   Speed = 23
-  "OSM\\.UseVirtualPCCursor" = true
+  "OSM\\.UseVirtualPCCursor" = 1
   ; speakTutorialMessages not supported?
   ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
   ; "Options\\.TypingEcho" = 1 

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1c_280_es.ini
@@ -1,0 +1,78 @@
+; screen reader settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1c_280_es"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 280
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = true
+  punctuationVerbosity = "most"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "es"
+  pitch = 0.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 23
+  "OSM\\.UseVirtualPCCursor" = true
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  "Options\\.SayAllIndicateCaps" = 1
+  Punctuation = 2
+  "Options\\.SayAllMode" = 2
+  Language = "Castilian Spanish"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 64
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "es"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=true
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 280
+  punctuationVerbosity= "most"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_de.ini
@@ -39,7 +39,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   Language = "German"
   ; @@Pitch range = 1 .. 100??
   Pitch = 80
-  ; "OSM\\.TrackFocusRect" = false
+  ; "OSM\\.TrackFocusRect" = 0
 
 
 [preferences]

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_de.ini
@@ -29,7 +29,7 @@ app = "http://registry.gpii.net/common"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   ; @@JAWS settings files have no setting to disable TTS??
   Speed = 25
-  "OSM\\.UseVirtualPCCursor" = true
+  "OSM\\.UseVirtualPCCursor" = 1
   ; speakTutorialMessages not supported?
   ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
   ; "Options\\.TypingEcho" = 1 

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_de.ini
@@ -1,0 +1,96 @@
+; screen reader and magnifier settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1d_300_de"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = false
+  punctuationVerbosity = "some"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "de"
+  pitch = 0.8
+  magnifierEnabled: true,
+  magnification: 2,
+  tracking: ["cursor"],
+  magnifierPosition: "TopHalf",
+  invertColours: true,
+  showCrosshairs: true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 25
+  "OSM\\.UseVirtualPCCursor" = true
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  ; "Options\\.SayAllIndicateCaps" is not in DEFAULT.JCF when it is disabled.
+  Punctuation = 1
+  "Options\\.SayAllMode" = 2
+  Language = "German"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 71
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "de"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=false
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  punctuationVerbosity= "some"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  Magnification = 200
+  FollowMouse = 0
+  FollowFocus = 1 
+  FollowCaret = 0
+  MagnificationMode = 1
+  Invert = 1
+  ; @@no crossHairs supported
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_el.ini
@@ -27,9 +27,10 @@ app = "http://registry.gpii.net/common"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  _disabled=true
   ; @@JAWS settings files have no setting to disable TTS??
   Speed = 25
-  "OSM\\.UseVirtualPCCursor" = true
+  "OSM\\.UseVirtualPCCursor" = 1
   ; speakTutorialMessages not supported?
   ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
   ; "Options\\.TypingEcho" = 1 
@@ -72,7 +73,6 @@ app = "http://registry.gpii.net/applications/org.nvda-project"
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
-  _disabled=true
   ; @@trackingTTS not supported
   screenReaderBrailleOutput = false
   screenReaderTTSEnabled = true

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_el.ini
@@ -40,7 +40,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   Language = "Greek"
   ; @@Pitch range = 1 .. 100??
   Pitch = 80
-  ; "OSM\\.TrackFocusRect" = false
+  ; "OSM\\.TrackFocusRect" = 0
 
 
 [preferences]

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_el.ini
@@ -1,0 +1,96 @@
+; screen reader and magnifier settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1d_300_el"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = false
+  punctuationVerbosity = "some"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "el"
+  pitch = 0.8
+  magnifierEnabled: true,
+  magnification: 2,
+  tracking: ["cursor"],
+  magnifierPosition: "TopHalf",
+  invertColours: true,
+  showCrosshairs: true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 25
+  "OSM\\.UseVirtualPCCursor" = true
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  ; "Options\\.SayAllIndicateCaps" is not in DEFAULT.JCF when it is disabled.
+  Punctuation = 1
+  "Options\\.SayAllMode" = 2
+  Language = "Greek"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 71
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "el"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=false
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  punctuationVerbosity= "some"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  Magnification = 200
+  FollowMouse = 0
+  FollowFocus = 1 
+  FollowCaret = 0
+  MagnificationMode = 1
+  Invert = 1
+  ; @@no crossHairs supported
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_es.ini
@@ -29,7 +29,7 @@ app = "http://registry.gpii.net/common"
 app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   ; @@JAWS settings files have no setting to disable TTS??
   Speed = 25
-  "OSM\\.UseVirtualPCCursor" = true
+  "OSM\\.UseVirtualPCCursor" = 1
   ; speakTutorialMessages not supported?
   ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
   ; "Options\\.TypingEcho" = 1 

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_es.ini
@@ -1,0 +1,96 @@
+; screen reader and magnifier settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1d_300_es"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = false
+  punctuationVerbosity = "some"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "es"
+  pitch = 0.8
+  magnifierEnabled: true,
+  magnification: 2,
+  tracking: ["cursor"],
+  magnifierPosition: "TopHalf",
+  invertColours: true,
+  showCrosshairs: true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 25
+  "OSM\\.UseVirtualPCCursor" = true
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  ; "Options\\.SayAllIndicateCaps" is not in DEFAULT.JCF when it is disabled.
+  Punctuation = 1
+  "Options\\.SayAllMode" = 2
+  Language = "Castilian Spanish"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 71
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "es"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=false
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  punctuationVerbosity= "some"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  Magnification = 200
+  FollowMouse = 0
+  FollowFocus = 1 
+  FollowCaret = 0
+  MagnificationMode = 1
+  Invert = 1
+  ; @@no crossHairs supported
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_1d_300_es.ini
@@ -39,7 +39,7 @@ app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
   Language = "Castilian Spanish"
   ; @@Pitch range = 1 .. 100??
   Pitch = 80
-  ; "OSM\\.TrackFocusRect" = false
+  ; "OSM\\.TrackFocusRect" = 0
 
 
 [preferences]

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_2_300_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_2_300_de.ini
@@ -1,0 +1,51 @@
+; screen reader settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_2_300_de"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  trackingTTS = ["caret", "focus"]
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = true
+  punctuationVerbosity = "most"
+  readingUnit = "sentence"
+  auditoryOutLanguage = "de"
+  pitch = 0.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 25
+  "OSM\\.TrackFocusRect" = 1
+  "OSM\\.UseVirtualPCCursor" = 1
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  "Options\\.SayAllIndicateCaps" = 1
+  Punctuation = 2
+  "Options\\.SayAllMode" = 1
+  Language = "German"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = 0
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  punctuationVerbosity= "most"
+  announceCapitals= true
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_2_300_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_2_300_el.ini
@@ -1,0 +1,51 @@
+; screen reader settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_2_300_el"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  trackingTTS = ["caret", "focus"]
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = true
+  punctuationVerbosity = "most"
+  readingUnit = "sentence"
+  auditoryOutLanguage = "el"
+  pitch = 0.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 25
+  "OSM\\.TrackFocusRect" = 1
+  "OSM\\.UseVirtualPCCursor" = 1
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  "Options\\.SayAllIndicateCaps" = 1
+  Punctuation = 2
+  "Options\\.SayAllMode" = 1
+  Language = "Greek"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = 0
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  punctuationVerbosity= "most"
+  announceCapitals= true
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_2_300_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_2_300_es.ini
@@ -1,0 +1,51 @@
+; screen reader settings on Windows
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_2_300_es"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  trackingTTS = ["caret", "focus"]
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = true
+  punctuationVerbosity = "most"
+  readingUnit = "sentence"
+  auditoryOutLanguage = "es"
+  pitch = 0.8
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 25
+  "OSM\\.TrackFocusRect" = 1
+  "OSM\\.UseVirtualPCCursor" = 1
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  "Options\\.SayAllIndicateCaps" = 1
+  Punctuation = 2
+  "Options\\.SayAllMode" = 1
+  Language = "Castilian Spanish"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = 0
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  punctuationVerbosity= "most"
+  announceCapitals= true
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_3_300_de.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_3_300_de.ini
@@ -1,0 +1,96 @@
+; screen reader and magnifier settings on Windows; NVDA enabled
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_3_300_de"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = false
+  punctuationVerbosity = "some"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "de"
+  pitch = 0.8
+  magnifierEnabled: true,
+  magnification: 2,
+  tracking: ["cursor"],
+  magnifierPosition: "TopHalf",
+  invertColours: true,
+  showCrosshairs: true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  _disabled=true
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 25
+  "OSM\\.UseVirtualPCCursor" = 1
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  ; "Options\\.SayAllIndicateCaps" is not in DEFAULT.JCF when it is disabled.
+  Punctuation = 1
+  "Options\\.SayAllMode" = 2
+  Language = "German"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = 0
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 71
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "de"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=false
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  punctuationVerbosity= "some"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  Magnification = 200
+  FollowMouse = 0
+  FollowFocus = 1 
+  FollowCaret = 0
+  MagnificationMode = 1
+  Invert = 1
+  ; @@no crossHairs supported
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_3_300_el.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_3_300_el.ini
@@ -1,0 +1,96 @@
+; screen reader and magnifier settings on Windows; NVDA enabled
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1d_300_el"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = false
+  punctuationVerbosity = "some"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "el"
+  pitch = 0.8
+  magnifierEnabled: true,
+  magnification: 2,
+  tracking: ["cursor"],
+  magnifierPosition: "TopHalf",
+  invertColours: true,
+  showCrosshairs: true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  _disabled=true
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 25
+  "OSM\\.UseVirtualPCCursor" = 1
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  ; "Options\\.SayAllIndicateCaps" is not in DEFAULT.JCF when it is disabled.
+  Punctuation = 1
+  "Options\\.SayAllMode" = 2
+  Language = "Greek"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = 0
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 71
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "el"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=false
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  punctuationVerbosity= "some"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  Magnification = 200
+  FollowMouse = 0
+  FollowFocus = 1 
+  FollowCaret = 0
+  MagnificationMode = 1
+  Invert = 1
+  ; @@no crossHairs supported
+

--- a/manualDataThirdPhase/pilot3apps/screenreader_p3_3_300_es.ini
+++ b/manualDataThirdPhase/pilot3apps/screenreader_p3_3_300_es.ini
@@ -1,0 +1,96 @@
+; screen reader and magnifier settings on Windows; NVDA enabled
+; screen reader with TTS; Braille is disabled
+[context]
+user = "screenreader_p3_1d_300_es"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  trackingTTS = "caret"
+  speakTutorialMessages = false
+  keyEcho = true
+  wordEcho = false
+  announceCapitals = false
+  punctuationVerbosity = "some"
+  readingUnit = "paragraph"
+  auditoryOutLanguage = "es"
+  pitch = 0.8
+  magnifierEnabled: true,
+  magnification: 2,
+  tracking: ["cursor"],
+  magnifierPosition: "TopHalf",
+  invertColours: true,
+  showCrosshairs: true
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.freedomscientific.jaws"
+  ; @@JAWS settings files have no setting to disable TTS??
+  Speed = 25
+  "OSM\\.UseVirtualPCCursor" = 1
+  ; speakTutorialMessages not supported?
+  ; "Options\\.TypingEcho" is not in DEFAULT.JCF when only keyEcho is enabled. 
+  ; "Options\\.TypingEcho" = 1 
+  ; "Options\\.SayAllIndicateCaps" is not in DEFAULT.JCF when it is disabled.
+  Punctuation = 1
+  "Options\\.SayAllMode" = 2
+  Language = "Castilian Spanish"
+  ; @@Pitch range = 1 .. 100??
+  Pitch = 80
+  ; "OSM\\.TrackFocusRect" = 0
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.nvda-project"
+  _disabled=true
+  ; screenReaderBrailleOutput (default = "noBraille")
+  "braille\\.display"= "noBraille"
+  ; screenReaderTTSEnabled
+  "speech\\.synth"= "espeak"
+  "speech\\.outputDevice"= "Microsoft Sound Mapper"
+  "speech\\.espeak\\.rate"= 71
+  ; auditoryOutLanguage
+  "speech\\.espeak\\.voice"= "es"
+  ; trackingTTS
+  "reviewCursor\\.followFocus"=false
+  "reviewCursor\\.followCaret"=true
+  "reviewCursor\\.followMouse"=false
+  ; punctuationVerbosity (default: some = 100)
+  "speech\\.symbolLevel"= 100
+  ; incorrrectly mapped to "display.textReadingHighlight.readingUnit" by a transformer: 
+  "virtualBuffers\\.autoSayAllOnPageLoad"=false
+  ; announceCapitals
+  "speech\\.espeak\\.sayCapForCapitals"=false
+  ; keyEcho and wordEcho
+  "keyboard\\.speakTypedCharacters"=true
+  "keyboard\\.speakTypedWords"=false
+  ; pitch * 100 (NVDA default = 40)
+  "speech\\.espeak\\.pitch"= 80
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.yourdolphin.supernova-as"
+  _disabled=true
+  ; @@trackingTTS not supported
+  screenReaderBrailleOutput = false
+  screenReaderTTSEnabled = true
+  speechRate = 300
+  punctuationVerbosity= "some"
+  announceCapitals= false
+  ; keyEcho and wordEcho
+  keyEcho= true
+  wordEcho= false
+
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  Magnification = 200
+  FollowMouse = 0
+  FollowFocus = 1 
+  FollowCaret = 0
+  MagnificationMode = 1
+  Invert = 1
+  ; @@no crossHairs supported
+


### PR DESCRIPTION
Training data for use cases 1a, 1b, 1c, 1d and 2 for matchmaker evaluation in Cloud4all's third pilot phase. These include settings for JAWS as a "ghost application" (i.e. one that has not or not fully been integrated with GPII). 
