### PR TITLE
GPII-1112: high contrast and colour inversion

### DIFF
--- a/manualDataThirdPhase/_invertColours_false.ini
+++ b/manualDataThirdPhase/_invertColours_false.ini
@@ -1,25 +1,24 @@
 [context]
-user = "_invertColours_true"
+user = "_invertColours_false"
 os = "windows"
 
 [preferences]
 app = "http://registry.gpii.net/common"
-  invertColours=true
+  invertColours=false
 
-[preferences]
-app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
-  _disabled=true
-  "screen-magnifier-enabled"= true
+;[preferences]
+;app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+;  "screen-magnifier-enabled"= false
 [preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   _disabled=true
-  mag-factor = 1
+  ;mag-factor = 1
   ; @@ghost: Universal Access -> Zoom Options -> Colour Effects -> White on Black: On
-  invert-lightness = true
+  invert-lightness = false
 
 [preferences]
 app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
   _disabled=true
-  Magnification = 100
-  Invert = true
+  ;Magnification = 100
+  Invert = false
 

--- a/manualDataThirdPhase/_invertColours_true.ini
+++ b/manualDataThirdPhase/_invertColours_true.ini
@@ -1,0 +1,25 @@
+[context]
+user = "_invertColours_true"
+os = "windows"
+
+[preferences]
+app = "http://registry.gpii.net/common"
+  invertColours=true
+
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled"= true
+[preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
+  _disabled=true
+  mag-factor = 1
+  ; @@ghost: Universal Access -> Zoom Options -> Colour Effects -> White on Black: On
+  invert-lightness = true
+
+[preferences]
+app = "http://registry.gpii.net/applications/com.microsoft.windows.magnifier"
+  _disabled=true
+  Magnification = 100
+  Invert = true
+
+

--- a/manualDataThirdPhase/ghostapps/_highContrastTheme_001.ini
+++ b/manualDataThirdPhase/ghostapps/_highContrastTheme_001.ini
@@ -14,6 +14,9 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
   icon-theme = "HighContrast"
 
 [preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled"= true
+[preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   _disabled=true
   mag-factor = 1

--- a/manualDataThirdPhase/ghostapps/_highContrastTheme_002.ini
+++ b/manualDataThirdPhase/ghostapps/_highContrastTheme_002.ini
@@ -14,6 +14,9 @@ app = "http://registry.gpii.net/applications/org.gnome.desktop.interface"
   icon-theme = "HighContrast"
 
 [preferences]
+app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.applications"
+  "screen-magnifier-enabled"= true
+[preferences]
 app = "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier"
   _disabled=true
   mag-factor = 1


### PR DESCRIPTION
- Changes to two files for high contrast: light foreground on dark background in GNOME shell requires a black-on-white theme combined with colour inversion.
- New training data for colour inversion (without enabling high contrast). 
